### PR TITLE
DMF-3963 : Inject script within gwt, avoid double injection

### DIFF
--- a/src/main/resources/META-INF/csrfguard.template.js
+++ b/src/main/resources/META-INF/csrfguard.template.js
@@ -27,6 +27,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 (function() {
+    if (window.csrfguarded) {
+        return;
+    }
+
     /**
      * Code to ensure our event always gets triggered when the DOM is updated.
      * @param obj
@@ -447,6 +451,7 @@
         addEvent(window,'load', function() {
             injectTokens(token_name, token_value);
         });
+        window.csrfguarded = true;
     } else {
         alert("OWASP CSRFGuard JavaScript was included from within an unauthorized domain!");
     }

--- a/src/main/resources/META-INF/spring/jahia-csrf-guard.xml
+++ b/src/main/resources/META-INF/spring/jahia-csrf-guard.xml
@@ -36,4 +36,12 @@
         <property name="applyOnConfigurations" value="page,gwt,preview"/>
         <property name="applyOnTemplateTypes" value="html,html-*"/>
     </bean>
+
+    <bean class="org.jahia.ajax.gwt.helper.ModuleGWTResources">
+        <property name="javascriptResources">
+            <list>
+                <value>/CsrfServlet</value>
+            </list>
+        </property>
+    </bean>
 </beans>


### PR DESCRIPTION
- Add injection in gwt resources, used for ExecuteActionItem or any XHR on .do generated by gwt
- Avoid double injection of the script, which can happen for example on portlet manager (script called by gwtresource and renderfilter in the same frame)