### PR TITLE
BACKLOG-14162: Fix char removed from response

### DIFF
--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/CsrfGuardJavascriptFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/CsrfGuardJavascriptFilter.java
@@ -80,7 +80,7 @@ public final class CsrfGuardJavascriptFilter extends AbstractServletFilter {
             String codeSnippet = buildCodeSnippet(httpRequest.getContextPath());
 
             PrintWriter writer = response.getWriter();
-            writer.write(originalContent.substring(0, indexOfCloseHeadTag - 1));
+            writer.write(originalContent.substring(0, indexOfCloseHeadTag));
             writer.write(codeSnippet);
             writer.write(originalContent.substring(indexOfCloseHeadTag));
 


### PR DESCRIPTION
## JIRA
https://jira.jahia.org/browse/BACKLOG-14162

## Description
Filter was unexpectedly removing one char from the response