### PR TITLE
BACKLOG-14158: get latest fixes from OWASP Js template

### DIFF
--- a/src/main/resources/META-INF/csrfguard.template.js
+++ b/src/main/resources/META-INF/csrfguard.template.js
@@ -292,21 +292,18 @@
             }
         }
 
-        var value = tokenValue;
         var action = form.getAttribute("action");
 
-        if(action != null && isValidUrl(action) && isDotDoUrl(action)) {
+        if (action != null && isValidUrl(action) && isDotDoUrl(action)) {
             var uri = parseUri(action);
-            value = pageTokens[uri] != null ? pageTokens[uri] : tokenValue;
+            var hidden = document.createElement("input");
+
+            hidden.setAttribute("type", "hidden");
+            hidden.setAttribute("name", tokenName);
+            hidden.setAttribute("value", (pageTokens[uri] != null ? pageTokens[uri] : tokenValue));
+
+            form.appendChild(hidden);
         }
-
-        var hidden = document.createElement("input");
-
-        hidden.setAttribute("type", "hidden");
-        hidden.setAttribute("name", tokenName);
-        hidden.setAttribute("value", value);
-
-        form.appendChild(hidden);
     }
 
     /** inject tokens as query string parameters into url **/


### PR DESCRIPTION
Get latest fixes from JS OWASP project: https://github.com/aramrami/OWASP-CSRFGuard/blob/master/csrfguard/src/main/resources/csrfguard.js

Only one thing have not been backport, it's this commit: https://github.com/aramrami/OWASP-CSRFGuard/commit/7eeb68403e8465aeb9eb934dcb40502f4c0d8032#diff-8eac6bf39a0d051c879824cf44bd85e8

As it also impact java classes, and config.
That was out of the scope, I just wanted to backport the various js specific issues and improvements.

All other fixes have been backported.

Major one was the override of String.startsWith and String.endsWith that was very dangerous and was breaking Content-editor.