### PR TITLE
BACKLOG-14215: Enable on-code-change workflow on 1-1-x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,7 @@ workflows:
                 - master
                 - /feature-.*/
                 - /[0-9]_[0-9]_x/
+                - /[0-9]-[0-9]-x/
       - build:
           is_pull_request: false
           context: QA_ENVIRONMENT


### PR DESCRIPTION
## JIRA
https://jira.jahia.org/browse/BACKLOG-14215

## Description
The branch patterns used by the on-code-change workflow did not cover the naming of "1-1-x" branch
