### PR TITLE
QA-13942: Add overridden properties before calling constructor

### DIFF
--- a/src/main/java/org/jahia/modules/jahiacsrfguard/config/overlay/ConfigurationOverlayProviderFactory.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/config/overlay/ConfigurationOverlayProviderFactory.java
@@ -48,6 +48,7 @@ public class ConfigurationOverlayProviderFactory implements
 	public ConfigurationProvider retrieveConfiguration(Properties originalProperties) {
 		ConfigurationOverlayProvider configurationOverlayProvider = ConfigurationOverlayProvider.retrieveConfig();
 		Properties properties = configurationOverlayProvider.properties();
+		properties.putAll(configurationOverlayProvider.propertiesOverrideMap());
 		
 		return new PropertiesConfigurationProvider(properties);
     }


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/QA-13942

## Description

Overridden properties were just taken in account when calling the ConfigPropertiesCascadeBase.propertyValue* methods, but should also be used for PropertiesConfigurationProvider convenience methods

