### PR TITLE
QA-13496: Do not set CSRFTOKEN as query-parameter to error.html

### DIFF
--- a/src/main/resources/META-INF/csrfguard-jahia.properties
+++ b/src/main/resources/META-INF/csrfguard-jahia.properties
@@ -35,6 +35,50 @@
 org.owasp.csrfguard.TokenPerPage=true
 org.owasp.csrfguard.TokenPerPagePrecreate=false
 
+#######################
+## Unprotected Pages ##
+#######################
+# The unprotected pages property (org.owasp.csrfguard.unprotected.*) defines a series of pages that
+# should not be protected by CSRFGuard. Such configurations are useful when the CsrfGuardFilter is
+# aggressively mapped (ex: /*). The syntax of the property name is org.owasp.csrfguard.unprotected.[PageName],
+# where PageName is some arbitrary identifier that can be used to reference a resource. The syntax of
+# defining the uri of unprotected pages is the same as the syntax used by the JavaEE container for uri mapping.
+# Specifically, CSRFGuard will identify the first match (if any) between the requested uri and an unprotected
+# page in order of declaration. Match criteria is as follows:
+#
+# Case 1: exact match between request uri and unprotected page
+# Case 2: longest path prefix match, beginning / and ending /*
+# Case 3: extension match, beginning *.
+# Case 4: if the value starts with ^ and ends with $, it will be evaluated as a regex.
+#   Note that before the regex is compiled, any common variables will be substituted (e.g. %servletContext%)
+# Default: requested resource must be validated by CSRFGuard
+#
+# The following code snippet illustrates the four use cases over four examples. The first two examples
+# (Tag and JavaScriptServlet) look for direct URI matches. The third example (Html) looks for all resources
+# ending in a .html extension. The next example (Public) looks for all resources prefixed with the URI path /MySite/Public/*.
+# The last example looks for resources that end in Public.do
+#
+# org.owasp.csrfguard.unprotected.Tag = %servletContext%/tag.jsp
+# org.owasp.csrfguard.unprotected.JavaScriptServlet = %servletContext%/JavaScriptServlet
+# org.owasp.csrfguard.unprotected.Html = *.html
+# org.owasp.csrfguard.unprotected.Public = %servletContext%/Public/*
+#
+# Regex example starts with ^ and ends with $, and the %servletContext% is evaluated before the regex:
+# org.owasp.csrfguard.unprotected.PublicServlet = ^%servletContext%/.*Public\.do$
+
+# org.owasp.csrfguard.unprotected.Default = %servletContext%/
+# org.owasp.csrfguard.unprotected.Upload = %servletContext%/upload.html
+# org.owasp.csrfguard.unprotected.JavaScriptServlet = %servletContext%/JavaScriptServlet
+# org.owasp.csrfguard.unprotected.Ajax = %servletContext%/ajax.html
+# org.owasp.csrfguard.unprotected.Error = %servletContext%/error.html
+# org.owasp.csrfguard.unprotected.Index = %servletContext%/index.html
+# org.owasp.csrfguard.unprotected.JavaScript = %servletContext%/javascript.html
+# org.owasp.csrfguard.unprotected.Tag = %servletContext%/tag.jsp
+# org.owasp.csrfguard.unprotected.Redirect = %servletContext%/redirect.jsp
+# org.owasp.csrfguard.unprotected.Forward = %servletContext%/forward.jsp
+# org.owasp.csrfguard.unprotected.Session = %servletContext%/session.jsp
+org.owasp.csrfguard.unprotected.Error = %servletContext%/error.html
+
 ################
 ## Token Name ##
 ################


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/QA-13496

## Description

Do not set CSRFTOKEN as query-parameter to error.html

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability

