### PR TITLE
BACKLOG-19988: Avoid classCastException when redploying module

### DIFF
--- a/src/main/java/org/jahia/modules/jahiacsrfguard/token/SessionTokenHolder.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/token/SessionTokenHolder.java
@@ -61,7 +61,11 @@ public class SessionTokenHolder implements TokenHolder {
         Token token = null;
         HttpSession session = getSession(sessionKey);
         if (session != null) {
-            token = (Token) session.getAttribute(CSRF_TOKEN);
+            try {
+                token = (Token) session.getAttribute(CSRF_TOKEN);
+            } catch (ClassCastException e) {
+                logger.debug("Invalid class for token, reset to new one");
+            }
             if (token == null) {
                 token = createToken(sessionKey, TokenUtils::generateRandomToken);
             }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19988

## Description

In case module is redeployed, old tokens are still present in session but class is incompatible.
