### PR TITLE
TECH-1738: Set NEXUS_INTERNAL_URL environment variable from secrets

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -34,7 +34,7 @@ jobs:
     needs: update-signature
     runs-on: ubuntu-latest
     env:
-      NEXUS_INTERNAL_URL: https://devtools.jahia.com/nexus/content/groups/internal/
+      NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }} 
     container:
       image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
       credentials:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -27,7 +27,7 @@ jobs:
     needs: update-signature
     runs-on: ubuntu-latest
     env:
-      NEXUS_INTERNAL_URL: https://devtools.jahia.com/nexus/content/groups/internal/
+      NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }} 
     container:
       image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
       credentials:
@@ -61,7 +61,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     env:
-      NEXUS_INTERNAL_URL: https://devtools.jahia.com/nexus/content/groups/internal/
+      NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }}
     container:
       image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
       credentials:

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: jahia/jahia-modules-action/release@v2
         name: Release Module
         env:
-          NEXUS_INTERNAL_URL: https://devtools.jahia.com/nexus/content/groups/internal/
+          NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }} 
         with:
           github_slug: Jahia/jahia-csrf-guard
           primary_release_branch: master

--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -14,6 +14,8 @@ jobs:
   sonar-analysis:
     name: Sonar Analysis
     runs-on: ubuntu-latest
+    env:
+      NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }} 
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -43,3 +43,4 @@ jobs:
           sonar_url: ${{ secrets.SONAR_URL }}
           sonar_token: ${{ secrets.SONAR_TOKEN }}
           mvn_settings_filepath: '.github/maven.settings.xml'
+          nvd_apikey: ${{ secrets.NVD_APIKEY }}


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/TECH-1738

## Description

Set `NEXUS_INTERNAL_URL` environment variable from secrets. For the `schedule-sonar` workflow it was missing completely, which was resulting in a constant error.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
