### PR TITLE
test: fix potential logout side effect by clearing client side cookies

### DIFF
--- a/tests/cypress/e2e/base.cy.ts
+++ b/tests/cypress/e2e/base.cy.ts
@@ -33,6 +33,7 @@ describe('Base CSRF tests', () => {
             });
         // Doing the same as guest should not contain CSRF Tokens
         cy.logout();
+        cy.clearAllCookies(); // Clear all cookies to be sure we are not logged in
         cy.log('The page should NOT contains CSRF Tokens when not logged');
         cy.visit('/en/sites/' + targetSiteKey + '/home.html');
         cy.get('head script[src^="/modules/CsrfServlet"]').should('not.exist');


### PR DESCRIPTION
## Description

I suspect that there is flackiness in cypress test when loading the same page twice, once logged in as root and the next time as guest. Adding a clearCookies at the cypress level may fix the potential problem.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [X] Integration Tests

## Checklist

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability