### PR TITLE
fix: fix race condition in the config that lead to a NPE.

### DIFF
--- a/.chachalog/MMtiY_EW.md
+++ b/.chachalog/MMtiY_EW.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+jahia-csrf-guard: patch
+---
+
+Fix race condition in the config that lead to a NPE. (#167)

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>jahia-csrf-guard</artifactId>
     <name>Jahia CSRF Guard</name>
-    <version>4.3.0-SNAPSHOT</version>
+    <version>4.2.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (jahia-csrf-guard) to protect Jahia from CSRF attack.</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>jahia-csrf-guard</artifactId>
     <name>Jahia CSRF Guard</name>
-    <version>4.2.1-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (jahia-csrf-guard) to protect Jahia from CSRF attack.</description>
 

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/CsrfGuardJavascriptFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/CsrfGuardJavascriptFilter.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang.StringUtils;
 import org.jahia.bin.filters.AbstractServletFilter;
 import org.jahia.bin.filters.CompositeFilter;
 import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardGlobalConfig;
+import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardService;
 import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.render.URLResolver;
 import org.jahia.services.usermanager.JahiaUserManagerService;
@@ -57,6 +58,9 @@ public final class CsrfGuardJavascriptFilter extends AbstractServletFilter {
 
     @Reference(service = JahiaCsrfGuardGlobalConfig.class, cardinality = ReferenceCardinality.MANDATORY)
     private volatile JahiaCsrfGuardGlobalConfig config;
+
+    @Reference(service = JahiaCsrfGuardService.class, cardinality = ReferenceCardinality.MANDATORY)
+    private volatile JahiaCsrfGuardService csrfGuardService;
 
     @Activate
     public void activate(BundleContext context) {

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/CsrfGuardServletFilterWrapper.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/CsrfGuardServletFilterWrapper.java
@@ -19,6 +19,7 @@ import org.jahia.bin.filters.AbstractServletFilter;
 import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardConfig;
 import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardConfigFactory;
 import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardGlobalConfig;
+import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardService;
 import org.jahia.modules.jahiacsrfguard.token.SessionTokenHolder;
 import org.jahia.services.content.JCRSessionFactory;
 import org.jahia.services.usermanager.JahiaUser;
@@ -44,6 +45,9 @@ public class CsrfGuardServletFilterWrapper extends AbstractServletFilter {
 
     @Reference(service = JahiaCsrfGuardGlobalConfig.class, cardinality = ReferenceCardinality.MANDATORY)
     private volatile JahiaCsrfGuardGlobalConfig globalConfig;
+
+    @Reference(service = JahiaCsrfGuardService.class, cardinality = ReferenceCardinality.MANDATORY)
+    private volatile JahiaCsrfGuardService csrfGuardService;
 
     private volatile Collection<JahiaCsrfGuardConfig> configs = new HashSet<>();
     private CsrfGuardFilter csrfGuardFilter;

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>jahia-csrf-guard</artifactId>
-            <version>4.2.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
## Root Cause

The NPE is a race condition between two independent OSGi components during startup.

### The chain of events:

1. CsrfGuard.config() (in the csrfguard 4.5.0 jar) checks if properties is null. If null, it returns a NullConfigurationProvider whose getLogicalSessionExtractor() returns null.
2. CsrfGuardJavascriptFilter and JahiaCsrfGuardService are both @Component(immediate = true) and both have a @Reference on JahiaCsrfGuardGlobalConfig with MANDATORY cardinality. They activate independently once that config becomes available.
3. JahiaCsrfGuardService.activate() calls CsrfGuardServletContextListener.contextInitialized() (line 97-98 of JahiaCsrfGuardService.java), which is what sets CsrfGuard.properties — making the real PropertiesConfigurationProvider available (which has a non-null LogicalSessionExtractor).
4. If CsrfGuardJavascriptFilter processes an HTTP request before JahiaCsrfGuardService.activate() completes, then JavaScriptServlet.getJavaScriptEtag() calls CsrfGuard.getInstance(), gets a CsrfGuard with null properties, which returns NullConfigurationProvider, which returns null for getLogicalSessionExtractor() → NPE.

### Why it didn't happen in 4.1.0:

In 4.1.0, the CsrfGuardJavascriptFilter did not call JavaScriptServlet.getJavaScriptEtag(). The buildCodeSnippet method was simpler and didn't need the CsrfGuard configuration to be initialized. The etag computation via JavaScriptServlet.getJavaScriptEtag() was added in the refactoring (commit 7ba622e).

## Fix applied 

Both CsrfGuardJavascriptFilter and CsrfGuardServletFilterWrapper now have a @Reference(service = JahiaCsrfGuardService.class, cardinality = ReferenceCardinality.MANDATORY). This ensures OSGi won't activate these filters until JahiaCsrfGuardService has fully activated — meaning CsrfGuardServletContextListener.contextInitialized() has already run and CsrfGuard has its properties set with a proper LogicalSessionExtractor.
Without this dependency, both filters could process requests while CsrfGuard was still uninitialized, causing it to fall back to NullConfigurationProvider which returns null for getLogicalSessionExtractor().