### PR TITLE
feat: remove dependency to Spring for Mutlipart Request 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
 
     <properties>
         <csrfguard.version>4.5.0</csrfguard.version>
+        <commons-fileupload.version>1.6.0</commons-fileupload.version>
         <jahia.plugin.version>6.12</jahia.plugin.version>
         <jahia-module-type>system</jahia-module-type>
         <jahia-module-signature>MC0CFQCW+DWFs42Lt4b7yBZW1yUmZDlCWgIUSmPmmxtZHg1TdNqojnAqpBVvPjU=</jahia-module-signature>
@@ -107,10 +108,22 @@
             <version>${csrfguard.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>${spring.version}</version>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+            <version>${commons-fileupload.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardGlobalConfig.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardGlobalConfig.java
@@ -28,9 +28,6 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.multipart.MultipartResolver;
-import org.springframework.web.multipart.commons.CommonsMultipartResolver;
-
 import java.util.*;
 
 /**
@@ -53,7 +50,6 @@ public class JahiaCsrfGuardGlobalConfig {
     private String servletPath = "";
     private boolean bypassForGuest = true;
     private List<String> resolvedUrlPatterns = new ArrayList<>();
-    private MultipartResolver multipartResolver;
 
     @Activate
     @Modified
@@ -67,7 +63,6 @@ public class JahiaCsrfGuardGlobalConfig {
         this.setResolvedUrlPatterns(config.getOrDefault(RESOLVED_URL_PATTERNS, "").isEmpty() ?
                 new ArrayList<>() :
                 List.of(config.get(RESOLVED_URL_PATTERNS).split(",")));
-        this.setMultipartResolver(new CommonsMultipartResolver());
         LOGGER.debug("Updated Jahia CSRF Guard Global configuration: {}", this);
     }
 
@@ -123,14 +118,6 @@ public class JahiaCsrfGuardGlobalConfig {
         this.resolvedUrlPatterns = resolvedUrlPatterns;
     }
 
-    public MultipartResolver getMultipartResolver() {
-        return multipartResolver;
-    }
-
-    public void setMultipartResolver(MultipartResolver multipartResolver) {
-        this.multipartResolver = multipartResolver;
-    }
-
     @Override public boolean equals(Object o) {
         if (this == o)
             return true;
@@ -138,12 +125,11 @@ public class JahiaCsrfGuardGlobalConfig {
             return false;
         JahiaCsrfGuardGlobalConfig that = (JahiaCsrfGuardGlobalConfig) o;
         return serviceEnabled == that.serviceEnabled && bypassForGuest == that.bypassForGuest && Objects.equals(servletAlias, that.servletAlias)
-                && Objects.equals(servletPath, that.servletPath) && Objects.equals(resolvedUrlPatterns, that.resolvedUrlPatterns)
-                && Objects.equals(multipartResolver, that.multipartResolver);
+                && Objects.equals(servletPath, that.servletPath) && Objects.equals(resolvedUrlPatterns, that.resolvedUrlPatterns);
     }
 
     @Override public int hashCode() {
-        return Objects.hash(serviceEnabled, servletAlias, servletPath, bypassForGuest, resolvedUrlPatterns, multipartResolver);
+        return Objects.hash(serviceEnabled, servletAlias, servletPath, bypassForGuest, resolvedUrlPatterns);
     }
 
     @Override public String toString() {

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/CsrfGuardServletFilterWrapper.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/CsrfGuardServletFilterWrapper.java
@@ -75,7 +75,11 @@ public class CsrfGuardServletFilterWrapper extends AbstractServletFilter {
             if (isEnabled() && matchUser() && isFiltered(request) && !isWhiteListed(request)) {
                 HttpServletRequest httpRequest = (HttpServletRequest) request;
                 if (request.getContentType() != null && request.getContentType().toLowerCase().startsWith("multipart/")) {
-                    request = globalConfig.getMultipartResolver().resolveMultipart(new MultiReadHttpServletRequest(httpRequest));
+                    try {
+                        request = new MultipartRequestWrapper(new MultiReadHttpServletRequest(httpRequest));
+                    } catch (org.apache.commons.fileupload.FileUploadException e) {
+                        LOGGER.error("Failed to parse multipart request", e);
+                    }
                 }
                 csrfGuardFilter.doFilter(request, response, chain);
                 return;

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/MultipartRequestWrapper.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/MultipartRequestWrapper.java
@@ -34,8 +34,6 @@ import java.util.*;
  */
 public class MultipartRequestWrapper extends HttpServletRequestWrapper {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MultipartRequestWrapper.class);
-
     private final Map<String, List<String>> multipartParameters;
 
     public MultipartRequestWrapper(HttpServletRequest request) throws FileUploadException {

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/MultipartRequestWrapper.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/MultipartRequestWrapper.java
@@ -19,8 +19,6 @@ import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/MultipartRequestWrapper.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/MultipartRequestWrapper.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2002-2025 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.jahiacsrfguard.filters;
+
+import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload.FileUploadException;
+import org.apache.commons.fileupload.disk.DiskFileItemFactory;
+import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.util.*;
+
+/**
+ * HttpServletRequest wrapper that parses multipart/form-data requests using Apache Commons FileUpload
+ * and exposes form field parameters via the standard getParameter API.
+ * This allows downstream filters (such as OWASP CsrfGuard) to read CSRF tokens
+ * from multipart form submissions using getParameter().
+ */
+public class MultipartRequestWrapper extends HttpServletRequestWrapper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MultipartRequestWrapper.class);
+
+    private final Map<String, List<String>> multipartParameters;
+
+    public MultipartRequestWrapper(HttpServletRequest request) throws FileUploadException {
+        super(request);
+        this.multipartParameters = parseMultipartParameters(request);
+    }
+
+    private static Map<String, List<String>> parseMultipartParameters(HttpServletRequest request) throws FileUploadException {
+        Map<String, List<String>> params = new LinkedHashMap<>();
+        ServletFileUpload upload = new ServletFileUpload(new DiskFileItemFactory());
+        List<FileItem> items = upload.parseRequest(request);
+        for (FileItem item : items) {
+            if (item.isFormField()) {
+                params.computeIfAbsent(item.getFieldName(), k -> new ArrayList<>()).add(item.getString());
+            }
+        }
+        return params;
+    }
+
+    @Override
+    public String getParameter(String name) {
+        List<String> values = multipartParameters.get(name);
+        if (values != null && !values.isEmpty()) {
+            return values.get(0);
+        }
+        return super.getParameter(name);
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        Map<String, String[]> originalParams = super.getParameterMap();
+        Map<String, String[]> merged = new LinkedHashMap<>(originalParams);
+        for (Map.Entry<String, List<String>> entry : multipartParameters.entrySet()) {
+            if (!merged.containsKey(entry.getKey())) {
+                merged.put(entry.getKey(), entry.getValue().toArray(new String[0]));
+            }
+        }
+        return Collections.unmodifiableMap(merged);
+    }
+
+    @Override
+    public Enumeration<String> getParameterNames() {
+        Set<String> names = new LinkedHashSet<>();
+        Enumeration<String> originalNames = super.getParameterNames();
+        while (originalNames.hasMoreElements()) {
+            names.add(originalNames.nextElement());
+        }
+        names.addAll(multipartParameters.keySet());
+        return Collections.enumeration(names);
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        String[] original = super.getParameterValues(name);
+        List<String> multipart = multipartParameters.get(name);
+        if (original == null && multipart == null) {
+            return null;
+        }
+        List<String> merged = new ArrayList<>();
+        if (original != null) {
+            merged.addAll(Arrays.asList(original));
+        }
+        if (multipart != null) {
+            merged.addAll(multipart);
+        }
+        return merged.toArray(new String[0]);
+    }
+}

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/filters/MultipartRequestWrapperTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/filters/MultipartRequestWrapperTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2002-2025 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.jahiacsrfguard.filters;
+
+import org.apache.commons.fileupload.FileUploadException;
+import org.junit.Test;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class MultipartRequestWrapperTest {
+
+    private static final String BOUNDARY = "----TestBoundary123";
+
+    /**
+     * Build a raw multipart/form-data body from a list of field name/value pairs.
+     */
+    private static byte[] buildMultipartBody(String boundary, String[]... fields) {
+        StringBuilder sb = new StringBuilder();
+        for (String[] field : fields) {
+            sb.append("--").append(boundary).append("\r\n");
+            sb.append("Content-Disposition: form-data; name=\"").append(field[0]).append("\"\r\n");
+            sb.append("\r\n");
+            sb.append(field[1]).append("\r\n");
+        }
+        sb.append("--").append(boundary).append("--\r\n");
+        return sb.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Create a mock HttpServletRequest with the given multipart body.
+     */
+    private static HttpServletRequest mockMultipartRequest(String boundary, byte[] body) throws IOException {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getContentType()).thenReturn("multipart/form-data; boundary=" + boundary);
+        when(request.getContentLength()).thenReturn(body.length);
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getCharacterEncoding()).thenReturn("UTF-8");
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(body);
+        ServletInputStream sis = new ServletInputStream() {
+            @Override public boolean isFinished() { return bais.available() == 0; }
+            @Override public boolean isReady() { return true; }
+            @Override public void setReadListener(ReadListener readListener) { }
+            @Override public int read() { return bais.read(); }
+        };
+        when(request.getInputStream()).thenReturn(sis);
+
+        // No query-string parameters on the underlying request
+        when(request.getParameterMap()).thenReturn(Collections.emptyMap());
+        when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+        when(request.getParameter(anyString())).thenReturn(null);
+        when(request.getParameterValues(anyString())).thenReturn(null);
+
+        return request;
+    }
+
+    @Test
+    public void testGetParameterReturnsCsrfToken() throws Exception {
+        byte[] body = buildMultipartBody(BOUNDARY,
+                new String[]{"OWASP-CSRFTOKEN", "abc-123-token"},
+                new String[]{"username", "john"});
+
+        HttpServletRequest mock = mockMultipartRequest(BOUNDARY, body);
+        MultipartRequestWrapper wrapper = new MultipartRequestWrapper(mock);
+
+        assertEquals("abc-123-token", wrapper.getParameter("OWASP-CSRFTOKEN"));
+        assertEquals("john", wrapper.getParameter("username"));
+    }
+
+    @Test
+    public void testGetParameterReturnsNullForMissingField() throws Exception {
+        byte[] body = buildMultipartBody(BOUNDARY, new String[]{"field1", "value1"});
+        HttpServletRequest mock = mockMultipartRequest(BOUNDARY, body);
+        MultipartRequestWrapper wrapper = new MultipartRequestWrapper(mock);
+
+        assertNull(wrapper.getParameter("nonexistent"));
+    }
+
+    @Test
+    public void testGetParameterMapContainsAllFields() throws Exception {
+        byte[] body = buildMultipartBody(BOUNDARY,
+                new String[]{"token", "t1"},
+                new String[]{"name", "Alice"});
+
+        HttpServletRequest mock = mockMultipartRequest(BOUNDARY, body);
+        MultipartRequestWrapper wrapper = new MultipartRequestWrapper(mock);
+
+        Map<String, String[]> paramMap = wrapper.getParameterMap();
+        assertEquals(2, paramMap.size());
+        assertArrayEquals(new String[]{"t1"}, paramMap.get("token"));
+        assertArrayEquals(new String[]{"Alice"}, paramMap.get("name"));
+    }
+
+    @Test
+    public void testGetParameterNamesContainsAllFields() throws Exception {
+        byte[] body = buildMultipartBody(BOUNDARY,
+                new String[]{"alpha", "1"},
+                new String[]{"beta", "2"});
+
+        HttpServletRequest mock = mockMultipartRequest(BOUNDARY, body);
+        MultipartRequestWrapper wrapper = new MultipartRequestWrapper(mock);
+
+        Set<String> names = new HashSet<>();
+        Enumeration<String> en = wrapper.getParameterNames();
+        while (en.hasMoreElements()) {
+            names.add(en.nextElement());
+        }
+        assertTrue(names.contains("alpha"));
+        assertTrue(names.contains("beta"));
+        assertEquals(2, names.size());
+    }
+
+    @Test
+    public void testGetParameterValuesForMultiValueField() throws Exception {
+        byte[] body = buildMultipartBody(BOUNDARY,
+                new String[]{"color", "red"},
+                new String[]{"color", "blue"});
+
+        HttpServletRequest mock = mockMultipartRequest(BOUNDARY, body);
+        MultipartRequestWrapper wrapper = new MultipartRequestWrapper(mock);
+
+        String[] values = wrapper.getParameterValues("color");
+        assertNotNull(values);
+        assertEquals(2, values.length);
+        assertEquals("red", values[0]);
+        assertEquals("blue", values[1]);
+    }
+
+    @Test
+    public void testGetParameterValuesReturnsNullForMissingField() throws Exception {
+        byte[] body = buildMultipartBody(BOUNDARY, new String[]{"a", "1"});
+        HttpServletRequest mock = mockMultipartRequest(BOUNDARY, body);
+        MultipartRequestWrapper wrapper = new MultipartRequestWrapper(mock);
+
+        assertNull(wrapper.getParameterValues("missing"));
+    }
+
+    @Test
+    public void testMultipartParametersMergeWithOriginalParams() throws Exception {
+        byte[] body = buildMultipartBody(BOUNDARY, new String[]{"token", "csrf-value"});
+        HttpServletRequest mock = mockMultipartRequest(BOUNDARY, body);
+
+        // Simulate a query-string parameter on the underlying request
+        Map<String, String[]> originalParams = new HashMap<>();
+        originalParams.put("queryParam", new String[]{"qval"});
+        when(mock.getParameterMap()).thenReturn(originalParams);
+        when(mock.getParameter("queryParam")).thenReturn("qval");
+        when(mock.getParameterValues("queryParam")).thenReturn(new String[]{"qval"});
+        when(mock.getParameterNames()).thenReturn(Collections.enumeration(Collections.singleton("queryParam")));
+
+        MultipartRequestWrapper wrapper = new MultipartRequestWrapper(mock);
+
+        // Both parameters should be accessible
+        assertEquals("csrf-value", wrapper.getParameter("token"));
+        assertEquals("qval", wrapper.getParameter("queryParam"));
+
+        Map<String, String[]> merged = wrapper.getParameterMap();
+        assertEquals(2, merged.size());
+        assertArrayEquals(new String[]{"csrf-value"}, merged.get("token"));
+        assertArrayEquals(new String[]{"qval"}, merged.get("queryParam"));
+    }
+
+    @Test
+    public void testParameterMapIsUnmodifiable() throws Exception {
+        byte[] body = buildMultipartBody(BOUNDARY, new String[]{"f", "v"});
+        HttpServletRequest mock = mockMultipartRequest(BOUNDARY, body);
+        MultipartRequestWrapper wrapper = new MultipartRequestWrapper(mock);
+
+        try {
+            wrapper.getParameterMap().put("new", new String[]{"val"});
+            fail("Expected UnsupportedOperationException");
+        } catch (UnsupportedOperationException expected) {
+            // ok
+        }
+    }
+
+    @Test
+    public void testFileFieldsAreIgnored() throws Exception {
+        // Build a body with a file part (has filename attribute) and a form field
+        StringBuilder sb = new StringBuilder();
+        sb.append("--").append(BOUNDARY).append("\r\n");
+        sb.append("Content-Disposition: form-data; name=\"file\"; filename=\"test.txt\"\r\n");
+        sb.append("Content-Type: text/plain\r\n");
+        sb.append("\r\n");
+        sb.append("file content here\r\n");
+        sb.append("--").append(BOUNDARY).append("\r\n");
+        sb.append("Content-Disposition: form-data; name=\"token\"\r\n");
+        sb.append("\r\n");
+        sb.append("csrf-val\r\n");
+        sb.append("--").append(BOUNDARY).append("--\r\n");
+
+        byte[] body = sb.toString().getBytes(StandardCharsets.UTF_8);
+        HttpServletRequest mock = mockMultipartRequest(BOUNDARY, body);
+        MultipartRequestWrapper wrapper = new MultipartRequestWrapper(mock);
+
+        // File field should not appear as parameter
+        assertNull(wrapper.getParameter("file"));
+        // Form field should be accessible
+        assertEquals("csrf-val", wrapper.getParameter("token"));
+        assertEquals(1, wrapper.getParameterMap().size());
+    }
+
+    @Test
+    public void testWorksWithMultiReadHttpServletRequest() throws Exception {
+        byte[] body = buildMultipartBody(BOUNDARY, new String[]{"csrf", "token-value"});
+        HttpServletRequest mock = mockMultipartRequest(BOUNDARY, body);
+
+        // Chain through MultiReadHttpServletRequest, as the production code does
+        MultiReadHttpServletRequest multiRead = new MultiReadHttpServletRequest(mock);
+        MultipartRequestWrapper wrapper = new MultipartRequestWrapper(multiRead);
+
+        assertEquals("token-value", wrapper.getParameter("csrf"));
+
+        // Verify the stream can still be read after parsing (the point of MultiReadHttpServletRequest)
+        byte[] reRead = new byte[body.length];
+        int bytesRead = multiRead.getInputStream().read(reRead);
+        assertTrue("Stream should be re-readable after multipart parsing", bytesRead > 0);
+    }
+}

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/filters/MultipartRequestWrapperTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/filters/MultipartRequestWrapperTest.java
@@ -15,7 +15,6 @@
  */
 package org.jahia.modules.jahiacsrfguard.filters;
 
-import org.apache.commons.fileupload.FileUploadException;
 import org.junit.Test;
 
 import javax.servlet.ReadListener;


### PR DESCRIPTION
### Description

This pull request refactors how multipart form data is handled for CSRF protection, replacing the previous dependency on Spring's multipart resolver with a new, custom solution based on Apache Commons FileUpload. This change simplifies dependencies and ensures CSRF tokens can be reliably extracted from multipart/form-data requests. The update also adds thorough unit tests for the new wrapper and adjusts project dependencies accordingly.

**Multipart handling refactor:**

* Introduced a new `MultipartRequestWrapper` class that parses multipart/form-data requests using Apache Commons FileUpload and exposes form fields (including CSRF tokens) via the standard `getParameter` API. This replaces the previous use of Spring's `MultipartResolver`. (`src/main/java/org/jahia/modules/jahiacsrfguard/filters/MultipartRequestWrapper.java`)
* Updated `CsrfGuardServletFilterWrapper` to wrap incoming multipart requests with the new `MultipartRequestWrapper`, removing all references to the Spring multipart resolver. (`src/main/java/org/jahia/modules/jahiacsrfguard/filters/CsrfGuardServletFilterWrapper.java`, `src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardGlobalConfig.java`) [[1]](diffhunk://#diff-75cbe53b8171da2111d03efaffe98231db77b0ca1dfa753cab173ed5538592d8L74-R78) [[2]](diffhunk://#diff-5c1c3fd893215e0bfb725817d52fea56b3d7371af1c980a12dc279d66eaebe81L31-L33) [[3]](diffhunk://#diff-5c1c3fd893215e0bfb725817d52fea56b3d7371af1c980a12dc279d66eaebe81L56) [[4]](diffhunk://#diff-5c1c3fd893215e0bfb725817d52fea56b3d7371af1c980a12dc279d66eaebe81L70) [[5]](diffhunk://#diff-5c1c3fd893215e0bfb725817d52fea56b3d7371af1c980a12dc279d66eaebe81L126-R132)

**Dependency and configuration updates:**

* Removed all dependencies and code references to Spring's multipart handling, and added Apache Commons FileUpload as a provided dependency. (`pom.xml`, `src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardGlobalConfig.java`) [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R43) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L110-R127) [[3]](diffhunk://#diff-5c1c3fd893215e0bfb725817d52fea56b3d7371af1c980a12dc279d66eaebe81L31-L33) [[4]](diffhunk://#diff-5c1c3fd893215e0bfb725817d52fea56b3d7371af1c980a12dc279d66eaebe81L56) [[5]](diffhunk://#diff-5c1c3fd893215e0bfb725817d52fea56b3d7371af1c980a12dc279d66eaebe81L70) [[6]](diffhunk://#diff-5c1c3fd893215e0bfb725817d52fea56b3d7371af1c980a12dc279d66eaebe81L126-R132)
* Added JUnit and Mockito as test dependencies for improved testing support. (`pom.xml`)

**Testing improvements:**

* Added comprehensive unit tests for `MultipartRequestWrapper`, ensuring correct extraction and merging of multipart and query parameters, proper handling of files, and compatibility with multi-read requests. (`src/test/java/org/jahia/modules/jahiacsrfguard/filters/MultipartRequestWrapperTest.java`)

### Checklist
#### Source code
- [X] I've shared and documented any breaking change
- [X] I've reviewed and updated the jahia-depends

#### Tests
- [X] I've provided Unit and/or Integration Tests
- [X] I've updated the parent issue with required manual validations
