### PR TITLE
feat: serve write requests only from the site's own browsing context

### DIFF
--- a/.chachalog/Qk3xRzPd.md
+++ b/.chachalog/Qk3xRzPd.md
@@ -6,3 +6,5 @@ jahia-csrf-guard: minor
 Restricted content changes to requests that the browser reports as coming from the site itself.
 
 Integrations that post to Jahia from another site, such as an identity provider or a notification service, must be listed in the `fetchMetadataWhitelist` property of a module configuration to keep working — the SAML callback already is. The check can be turned off by setting `fetchMetadata.enabled` to `false` in the module's global configuration.
+
+URL pattern and whitelist matching now strips matrix parameters (`;name=value`) from the request path before matching, so a pattern or whitelist entry is compared against the path Jahia resolves. This also applies to the existing `urlPatterns` and `whitelist` used by token validation.

--- a/.chachalog/Qk3xRzPd.md
+++ b/.chachalog/Qk3xRzPd.md
@@ -1,0 +1,8 @@
+---
+# Allowed version bumps: patch, minor, major
+jahia-csrf-guard: minor
+---
+
+Restricted content changes to requests that the browser reports as coming from the site itself.
+
+Integrations that post to Jahia from another site, such as an identity provider or a notification service, must be listed in the `fetchMetadataWhitelist` property of a module configuration to keep working — the SAML callback already is. The check can be turned off by setting `fetchMetadata.enabled` to `false` in the module's global configuration.

--- a/.chachalog/Qk3xRzPd.md
+++ b/.chachalog/Qk3xRzPd.md
@@ -5,6 +5,6 @@ jahia-csrf-guard: minor
 
 Restricted content changes to requests that the browser reports as coming from the site itself.
 
-Integrations that post to Jahia from another site, such as an identity provider or a notification service, must be listed in the `fetchMetadataWhitelist` property of a module configuration to keep working — the SAML callback already is. The check can be turned off by setting `fetchMetadata.enabled` to `false` in the module's global configuration.
+Integrations that post to Jahia from another site, such as an identity provider or a notification service, must be listed in the `crossSiteWriteWhitelist` property of a module configuration to keep working — the SAML callback already is. The check can be turned off by setting `crossSiteWriteProtection.enabled` to `false` in the module's global configuration.
 
 URL pattern and whitelist matching now strips matrix parameters (`;name=value`) from the request path before matching, so a pattern or whitelist entry is compared against the path Jahia resolves. This also applies to the existing `urlPatterns` and `whitelist` used by token validation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,10 +114,12 @@ Alongside token validation, the module applies a fetch metadata request policy: 
 Modern browsers describe the initiator of every request in the [`Sec-Fetch-Site`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site) request header, and a page cannot alter it. When that header holds `cross-site` and the request writes content, Jahia answers `403` and logs:
 
 ```
-WARN  [FetchMetadataFilter] - Rejected request (ip:..., method:POST, uri:..., Sec-Fetch-Site:cross-site)
+WARN  [FetchMetadataFilter] - Rejected request (ip:..., method:POST, uri:..., Sec-Fetch-Site:cross-site, Origin:https://attacker.example)
 ```
 
 A request writes content when its HTTP method is `POST`, `PUT`, `DELETE` or `PATCH`, or when it asks Jahia to act upon one of those methods through the `jcrMethodToCall` query parameter. Requests that only read, requests whose initiator is the site itself (`same-origin`, `same-site`), requests the user started themselves (`none`) and requests carrying no such header (non-browser clients, for instance a script or a server-to-server call) are served as usual.
+
+Because the policy keys off a header the browser must send, it complements token validation rather than replacing it. A client that never sends `Sec-Fetch-Site` — a non-browser caller, or a browser predating the header — falls into the header-absent case above and is served; such requests remain covered by token validation.
 
 #### Allowing a URL to be reached from another site
 
@@ -132,6 +134,8 @@ The policy covers all URLs; the `fetchMetadataUrlPatterns` property narrows it d
 ```
 fetchMetadataUrlPatterns = /cms/*, /en/sites/mysite/*
 ```
+
+> **Write these patterns against the URLs browsers request, not the ones Jahia resolves them to.** The filter runs on the incoming request (`REQUEST` dispatch) and matches its original URI. A content write to a site URL such as `POST /en/sites/mysite/home/foo` is served through an internal forward to `/cms/render/…`, which this filter never sees — so a scope of `/cms/*` on its own would match only the forwarded path and leave the original request uncovered. List the public entry-point spellings your writes actually use, or keep the default (all URLs), which is the safe choice.
 
 Both properties accept the same comma-separated URL patterns as `urlPatterns` and `whitelist`, and apply across all sites of the platform.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,7 +114,7 @@ Alongside token validation, the module applies a fetch metadata request policy: 
 Modern browsers describe the initiator of every request in the [`Sec-Fetch-Site`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site) request header, and a page cannot alter it. When that header holds `cross-site` and the request writes content, Jahia answers `403` and logs:
 
 ```
-WARN  [FetchMetadataFilter] - Rejected request (ip:..., method:POST, uri:..., Sec-Fetch-Site:cross-site, Origin:https://attacker.example)
+WARN  [FetchMetadataFilter] - Rejected request (ip:..., method:POST, uri:..., Sec-Fetch-Site:cross-site, Origin:https://other-website.com)
 ```
 
 A request writes content when its HTTP method is `POST`, `PUT`, `DELETE` or `PATCH`, or when it asks Jahia to act upon one of those methods through the `jcrMethodToCall` query parameter. Requests that only read, requests whose initiator is the site itself (`same-origin`, `same-site`), requests the user started themselves (`none`) and requests carrying no such header (non-browser clients, for instance a script or a server-to-server call) are served as usual.
@@ -146,6 +146,10 @@ The policy can be turned off in `/karaf/etc/org.jahia.modules.jahiacsrfguard.glo
 ```
 jahia.csrf-guard.crossSiteWriteProtection.enabled = false
 ```
+
+:::warning
+Disabling the policy removes the cross-site write protection layer: content-writing requests the browser reports as `cross-site` are no longer answered with `403`. Only token validation is left to guard against cross-site requests, so turn this off only when you have a specific reason to and understand the exposure.
+:::
 
 :::info
 Only browsers send `Sec-Fetch-*` headers, so this policy complements token validation rather than replacing it. Check that your reverse proxy forwards request headers it does not know, otherwise the policy has nothing to read.

--- a/docs/README.md
+++ b/docs/README.md
@@ -123,16 +123,16 @@ Because the policy keys off a header the browser must send, it complements token
 
 #### Allowing a URL to be reached from another site
 
-Some URLs are reached from another site by design — an identity provider posting an assertion back to Jahia, or a service posting a notification. The SAML callback (`*.saml`) is always exempt; any other URL is exempted by listing it in the `fetchMetadataWhitelist` property of a module configuration, for instance in `src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard-test-module.cfg`:
+Some URLs are reached from another site by design — an identity provider posting an assertion back to Jahia, or a service posting a notification. The SAML callback (`*.saml`) is always exempt; any other URL is exempted by listing it in the `crossSiteWriteWhitelist` property of a module configuration, for instance in `src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard-test-module.cfg`:
 
 ```
-fetchMetadataWhitelist = /my-module/notifications/*
+crossSiteWriteWhitelist = /my-module/notifications/*
 ```
 
-The policy covers all URLs; the `fetchMetadataUrlPatterns` property narrows it down to the URLs you list:
+The policy covers all URLs; the `crossSiteWriteUrlPatterns` property narrows it down to the URLs you list:
 
 ```
-fetchMetadataUrlPatterns = /cms/*, /en/sites/mysite/*
+crossSiteWriteUrlPatterns = /cms/*, /en/sites/mysite/*
 ```
 
 > **Write these patterns against the URLs browsers request, not the ones Jahia resolves them to.** The filter runs on the incoming request (`REQUEST` dispatch) and matches its original URI. A content write to a site URL such as `POST /en/sites/mysite/home/foo` is served through an internal forward to `/cms/render/…`, which this filter never sees — so a scope of `/cms/*` on its own would match only the forwarded path and leave the original request uncovered. List the public entry-point spellings your writes actually use, or keep the default (all URLs), which is the safe choice.
@@ -144,7 +144,7 @@ Both properties accept the same comma-separated URL patterns as `urlPatterns` an
 The policy can be turned off in `/karaf/etc/org.jahia.modules.jahiacsrfguard.global.cfg`:
 
 ```
-jahia.csrf-guard.fetchMetadata.enabled = false
+jahia.csrf-guard.crossSiteWriteProtection.enabled = false
 ```
 
 :::info

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,6 +107,46 @@ The usage of tokens per-page can be deactivated in Jahia 8.1+ by setting the fol
 org.owasp.csrfguard.TokenPerPage = false
 ```
 
+### Fetch metadata request policy
+
+Alongside token validation, the module applies a fetch metadata request policy: a request that writes content is served only when the browser reports it as coming from the site's own browsing context.
+
+Modern browsers describe the initiator of every request in the [`Sec-Fetch-Site`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site) request header, and a page cannot alter it. When that header holds `cross-site` and the request writes content, Jahia answers `403` and logs:
+
+```
+WARN  [FetchMetadataFilter] - Rejected request (ip:..., method:POST, uri:..., Sec-Fetch-Site:cross-site)
+```
+
+A request writes content when its HTTP method is `POST`, `PUT`, `DELETE` or `PATCH`, or when it asks Jahia to act upon one of those methods through the `jcrMethodToCall` query parameter. Requests that only read, requests whose initiator is the site itself (`same-origin`, `same-site`), requests the user started themselves (`none`) and requests carrying no such header (non-browser clients, for instance a script or a server-to-server call) are served as usual.
+
+#### Allowing a URL to be reached from another site
+
+Some URLs are reached from another site by design — an identity provider posting an assertion back to Jahia, or a service posting a notification. The SAML callback (`*.saml`) is always exempt; any other URL is exempted by listing it in the `fetchMetadataWhitelist` property of a module configuration, for instance in `src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard-test-module.cfg`:
+
+```
+fetchMetadataWhitelist = /my-module/notifications/*
+```
+
+The policy covers all URLs; the `fetchMetadataUrlPatterns` property narrows it down to the URLs you list:
+
+```
+fetchMetadataUrlPatterns = /cms/*, /en/sites/mysite/*
+```
+
+Both properties accept the same comma-separated URL patterns as `urlPatterns` and `whitelist`, and apply across all sites of the platform.
+
+#### Disabling the policy
+
+The policy can be turned off in `/karaf/etc/org.jahia.modules.jahiacsrfguard.global.cfg`:
+
+```
+jahia.csrf-guard.fetchMetadata.enabled = false
+```
+
+:::info
+Only browsers send `Sec-Fetch-*` headers, so this policy complements token validation rather than replacing it. Check that your reverse proxy forwards request headers it does not know, otherwise the policy has nothing to read.
+:::
+
 ### Caching considerations
 
 Starting from jahia-csrf-guard 4.2.0, CSRF guard javascript injection is disabled for guest users (unauthenticated users) by default.

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfig.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfig.java
@@ -36,10 +36,14 @@ public class JahiaCsrfGuardConfig {
 
     public static final String URL_PATTERNS = "urlPatterns";
     public static final String WHITELIST = "whitelist";
+    public static final String FETCH_METADATA_URL_PATTERNS = "fetchMetadataUrlPatterns";
+    public static final String FETCH_METADATA_WHITELIST = "fetchMetadataWhitelist";
 
     private String pid;
     private List<Pattern> urlPatterns;
     private List<Pattern> whitelistPatterns;
+    private List<Pattern> fetchMetadataUrlPatterns;
+    private List<Pattern> fetchMetadataWhitelistPatterns;
 
     public JahiaCsrfGuardConfig() {
     }
@@ -56,15 +60,35 @@ public class JahiaCsrfGuardConfig {
         if (StringUtils.isNotEmpty(whitelist)) {
             config.setWhitelist(whitelist);
         }
+        String fetchMetadataUrlPatterns = (String) properties.get(FETCH_METADATA_URL_PATTERNS);
+        if (StringUtils.isNotEmpty(fetchMetadataUrlPatterns)) {
+            config.setFetchMetadataUrlPatterns(fetchMetadataUrlPatterns);
+        }
+        String fetchMetadataWhitelist = (String) properties.get(FETCH_METADATA_WHITELIST);
+        if (StringUtils.isNotEmpty(fetchMetadataWhitelist)) {
+            config.setFetchMetadataWhitelist(fetchMetadataWhitelist);
+        }
         return config;
     }
 
     public void setUrlPatterns(String urlPatterns) {
-        this.urlPatterns = Arrays.stream(urlPatterns.split(",")).map(String::trim).map(JahiaCsrfGuardConfig::createUrlPattern).collect(Collectors.toList());
+        this.urlPatterns = compile(urlPatterns);
     }
 
     public void setWhitelist(String whitelist) {
-        this.whitelistPatterns = Arrays.stream(whitelist.split(",")).map(String::trim).map(JahiaCsrfGuardConfig::createUrlPattern).collect(Collectors.toList());
+        this.whitelistPatterns = compile(whitelist);
+    }
+
+    public void setFetchMetadataUrlPatterns(String fetchMetadataUrlPatterns) {
+        this.fetchMetadataUrlPatterns = compile(fetchMetadataUrlPatterns);
+    }
+
+    public void setFetchMetadataWhitelist(String fetchMetadataWhitelist) {
+        this.fetchMetadataWhitelistPatterns = compile(fetchMetadataWhitelist);
+    }
+
+    private static List<Pattern> compile(String patterns) {
+        return Arrays.stream(patterns.split(",")).map(String::trim).map(JahiaCsrfGuardConfig::createUrlPattern).collect(Collectors.toList());
     }
 
     /**
@@ -89,12 +113,7 @@ public class JahiaCsrfGuardConfig {
      * @return true if CsrfGuardFilter should be applied
      */
     public boolean isFiltered(ServletRequest request) {
-        if (urlPatterns == null) {
-            return false;
-        }
-
-        String uri = ((HttpServletRequest) request).getRequestURI();
-        return urlPatterns.stream().anyMatch(pattern -> pattern.matcher(uri).matches());
+        return matches(urlPatterns, request);
     }
 
     /**
@@ -103,11 +122,40 @@ public class JahiaCsrfGuardConfig {
      * @return true if URL is whitelisted for CsrfGuardFilter, so it should not be applied
      */
     public boolean isWhiteListed(ServletRequest request) {
-        if (whitelistPatterns == null) {
+        return matches(whitelistPatterns, request);
+    }
+
+    /**
+     * @return true if this configuration sets the scope of the fetch metadata request policy
+     */
+    public boolean hasFetchMetadataUrlPatterns() {
+        return fetchMetadataUrlPatterns != null;
+    }
+
+    /**
+     * Check url patterns configuration to see whether the fetch metadata request policy applies to the current request
+     * @param request client request object for servlet
+     * @return true if the policy should be applied
+     */
+    public boolean isFetchMetadataFiltered(ServletRequest request) {
+        return matches(fetchMetadataUrlPatterns, request);
+    }
+
+    /**
+     * Check whitelist configuration to see whether the fetch metadata request policy is bypassed for the current request
+     * @param request client request object for servlet
+     * @return true if URL is whitelisted, so the policy should not be applied
+     */
+    public boolean isFetchMetadataWhiteListed(ServletRequest request) {
+        return matches(fetchMetadataWhitelistPatterns, request);
+    }
+
+    private static boolean matches(List<Pattern> patterns, ServletRequest request) {
+        if (patterns == null) {
             return false;
         }
         String uri = ((HttpServletRequest) request).getRequestURI();
-        return whitelistPatterns.stream().anyMatch(pattern -> pattern.matcher(uri).matches());
+        return patterns.stream().anyMatch(pattern -> pattern.matcher(uri).matches());
     }
 
     @Override

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfig.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfig.java
@@ -154,8 +154,21 @@ public class JahiaCsrfGuardConfig {
         if (patterns == null) {
             return false;
         }
-        String uri = ((HttpServletRequest) request).getRequestURI();
+        String uri = normalizePath(((HttpServletRequest) request).getRequestURI());
         return patterns.stream().anyMatch(pattern -> pattern.matcher(uri).matches());
+    }
+
+    /**
+     * Strip the matrix parameters from every segment of a request URI, so a pattern is matched against the path Jahia
+     * resolves rather than the raw URI. Without this, a cross-site write to {@code /home.html;x=.saml} would end in
+     * {@code .saml}, match a {@code *.saml} whitelist and bypass the policy, while Jahia's Render dispatch drops the
+     * matrix parameter and still writes {@code /home.html}. The query string is not part of the URI, so it is untouched.
+     *
+     * @param uri a raw request URI, may be null
+     * @return the URI with each segment's {@code ;matrix=params} removed
+     */
+    public static String normalizePath(String uri) {
+        return uri == null ? "" : uri.replaceAll(";[^/]*", "");
     }
 
     @Override

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfig.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfig.java
@@ -36,14 +36,14 @@ public class JahiaCsrfGuardConfig {
 
     public static final String URL_PATTERNS = "urlPatterns";
     public static final String WHITELIST = "whitelist";
-    public static final String FETCH_METADATA_URL_PATTERNS = "fetchMetadataUrlPatterns";
-    public static final String FETCH_METADATA_WHITELIST = "fetchMetadataWhitelist";
+    public static final String CROSS_SITE_WRITE_URL_PATTERNS = "crossSiteWriteUrlPatterns";
+    public static final String CROSS_SITE_WRITE_WHITELIST = "crossSiteWriteWhitelist";
 
     private String pid;
     private List<Pattern> urlPatterns;
     private List<Pattern> whitelistPatterns;
-    private List<Pattern> fetchMetadataUrlPatterns;
-    private List<Pattern> fetchMetadataWhitelistPatterns;
+    private List<Pattern> crossSiteWriteUrlPatterns;
+    private List<Pattern> crossSiteWriteWhitelistPatterns;
 
     public JahiaCsrfGuardConfig() {
     }
@@ -60,13 +60,13 @@ public class JahiaCsrfGuardConfig {
         if (StringUtils.isNotEmpty(whitelist)) {
             config.setWhitelist(whitelist);
         }
-        String fetchMetadataUrlPatterns = (String) properties.get(FETCH_METADATA_URL_PATTERNS);
-        if (StringUtils.isNotEmpty(fetchMetadataUrlPatterns)) {
-            config.setFetchMetadataUrlPatterns(fetchMetadataUrlPatterns);
+        String crossSiteWriteUrlPatterns = (String) properties.get(CROSS_SITE_WRITE_URL_PATTERNS);
+        if (StringUtils.isNotEmpty(crossSiteWriteUrlPatterns)) {
+            config.setCrossSiteWriteUrlPatterns(crossSiteWriteUrlPatterns);
         }
-        String fetchMetadataWhitelist = (String) properties.get(FETCH_METADATA_WHITELIST);
-        if (StringUtils.isNotEmpty(fetchMetadataWhitelist)) {
-            config.setFetchMetadataWhitelist(fetchMetadataWhitelist);
+        String crossSiteWriteWhitelist = (String) properties.get(CROSS_SITE_WRITE_WHITELIST);
+        if (StringUtils.isNotEmpty(crossSiteWriteWhitelist)) {
+            config.setCrossSiteWriteWhitelist(crossSiteWriteWhitelist);
         }
         return config;
     }
@@ -79,12 +79,12 @@ public class JahiaCsrfGuardConfig {
         this.whitelistPatterns = compile(whitelist);
     }
 
-    public void setFetchMetadataUrlPatterns(String fetchMetadataUrlPatterns) {
-        this.fetchMetadataUrlPatterns = compile(fetchMetadataUrlPatterns);
+    public void setCrossSiteWriteUrlPatterns(String crossSiteWriteUrlPatterns) {
+        this.crossSiteWriteUrlPatterns = compile(crossSiteWriteUrlPatterns);
     }
 
-    public void setFetchMetadataWhitelist(String fetchMetadataWhitelist) {
-        this.fetchMetadataWhitelistPatterns = compile(fetchMetadataWhitelist);
+    public void setCrossSiteWriteWhitelist(String crossSiteWriteWhitelist) {
+        this.crossSiteWriteWhitelistPatterns = compile(crossSiteWriteWhitelist);
     }
 
     private static List<Pattern> compile(String patterns) {
@@ -128,8 +128,8 @@ public class JahiaCsrfGuardConfig {
     /**
      * @return true if this configuration sets the scope of the fetch metadata request policy
      */
-    public boolean hasFetchMetadataUrlPatterns() {
-        return fetchMetadataUrlPatterns != null;
+    public boolean hasCrossSiteWriteUrlPatterns() {
+        return crossSiteWriteUrlPatterns != null;
     }
 
     /**
@@ -137,8 +137,8 @@ public class JahiaCsrfGuardConfig {
      * @param request client request object for servlet
      * @return true if the policy should be applied
      */
-    public boolean isFetchMetadataFiltered(ServletRequest request) {
-        return matches(fetchMetadataUrlPatterns, request);
+    public boolean isCrossSiteWriteFiltered(ServletRequest request) {
+        return matches(crossSiteWriteUrlPatterns, request);
     }
 
     /**
@@ -146,8 +146,8 @@ public class JahiaCsrfGuardConfig {
      * @param request client request object for servlet
      * @return true if URL is whitelisted, so the policy should not be applied
      */
-    public boolean isFetchMetadataWhiteListed(ServletRequest request) {
-        return matches(fetchMetadataWhitelistPatterns, request);
+    public boolean isCrossSiteWriteWhiteListed(ServletRequest request) {
+        return matches(crossSiteWriteWhitelistPatterns, request);
     }
 
     private static boolean matches(List<Pattern> patterns, ServletRequest request) {

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfigFactory.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfigFactory.java
@@ -23,8 +23,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Dictionary;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Dynamic configuration to mainly set url patterns to apply CsrfGuardFilter on a request and whitelisting urls, which should be bypassed.
@@ -34,7 +34,10 @@ public class JahiaCsrfGuardConfigFactory implements ManagedServiceFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JahiaCsrfGuardConfigFactory.class);
 
-    private final Map<String, JahiaCsrfGuardConfig> configs = new HashMap<>();
+    // A concurrent map so the live values() view handed to the filters stays safe to iterate on request threads while
+    // ConfigAdmin mutates it through updated()/deleted(): the reference to the factory is bound once and never re-bound
+    // on a configuration change, so the filters keep iterating that same view.
+    private final Map<String, JahiaCsrfGuardConfig> configs = new ConcurrentHashMap<>();
 
     public JahiaCsrfGuardConfigFactory() {
         LOGGER.debug("Creating Jahia CSRF Guard Config Factory");

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardGlobalConfig.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardGlobalConfig.java
@@ -43,6 +43,7 @@ public class JahiaCsrfGuardGlobalConfig {
     public static final String SERVLET_ALIAS = "jahia.csrf-guard.servletAlias";
     public static final String BYPASS_FOR_GUEST = "jahia.csrf-guard.bypassForGuest";
     public static final String RESOLVED_URL_PATTERNS = "jahia.csrf-guard.resolvedUrlPatterns";
+    public static final String FETCH_METADATA_ENABLED = "jahia.csrf-guard.fetchMetadata.enabled";
 
     private Map<String, String> config = new HashMap<>();
     private boolean serviceEnabled = true;
@@ -50,6 +51,7 @@ public class JahiaCsrfGuardGlobalConfig {
     private String servletPath = "";
     private boolean bypassForGuest = true;
     private List<String> resolvedUrlPatterns = new ArrayList<>();
+    private boolean fetchMetadataEnabled = true;
 
     @Activate
     @Modified
@@ -63,6 +65,7 @@ public class JahiaCsrfGuardGlobalConfig {
         this.setResolvedUrlPatterns(config.getOrDefault(RESOLVED_URL_PATTERNS, "").isEmpty() ?
                 new ArrayList<>() :
                 List.of(config.get(RESOLVED_URL_PATTERNS).split(",")));
+        this.setFetchMetadataEnabled(config.getOrDefault(FETCH_METADATA_ENABLED, "true").equalsIgnoreCase("true"));
         LOGGER.debug("Updated Jahia CSRF Guard Global configuration: {}", this);
     }
 
@@ -118,6 +121,17 @@ public class JahiaCsrfGuardGlobalConfig {
         this.resolvedUrlPatterns = resolvedUrlPatterns;
     }
 
+    /**
+     * @return true when write requests are accepted only from the site's own browsing context
+     */
+    public boolean isFetchMetadataEnabled() {
+        return fetchMetadataEnabled;
+    }
+
+    public void setFetchMetadataEnabled(boolean fetchMetadataEnabled) {
+        this.fetchMetadataEnabled = fetchMetadataEnabled;
+    }
+
     @Override public boolean equals(Object o) {
         if (this == o)
             return true;
@@ -125,15 +139,16 @@ public class JahiaCsrfGuardGlobalConfig {
             return false;
         JahiaCsrfGuardGlobalConfig that = (JahiaCsrfGuardGlobalConfig) o;
         return serviceEnabled == that.serviceEnabled && bypassForGuest == that.bypassForGuest && Objects.equals(servletAlias, that.servletAlias)
-                && Objects.equals(servletPath, that.servletPath) && Objects.equals(resolvedUrlPatterns, that.resolvedUrlPatterns);
+                && Objects.equals(servletPath, that.servletPath) && Objects.equals(resolvedUrlPatterns, that.resolvedUrlPatterns)
+                && fetchMetadataEnabled == that.fetchMetadataEnabled;
     }
 
     @Override public int hashCode() {
-        return Objects.hash(serviceEnabled, servletAlias, servletPath, bypassForGuest, resolvedUrlPatterns);
+        return Objects.hash(serviceEnabled, servletAlias, servletPath, bypassForGuest, resolvedUrlPatterns, fetchMetadataEnabled);
     }
 
     @Override public String toString() {
         return "JahiaCsrfGuardGlobalConfig{" + "enabled=" + serviceEnabled + ", servletPath='" + servletPath + '\'' + ", bypassForGuest="
-                + bypassForGuest + ", resolvedUrlPatterns=" + resolvedUrlPatterns + '}';
+                + bypassForGuest + ", resolvedUrlPatterns=" + resolvedUrlPatterns + ", fetchMetadataEnabled=" + fetchMetadataEnabled + '}';
     }
 }

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardGlobalConfig.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardGlobalConfig.java
@@ -43,7 +43,7 @@ public class JahiaCsrfGuardGlobalConfig {
     public static final String SERVLET_ALIAS = "jahia.csrf-guard.servletAlias";
     public static final String BYPASS_FOR_GUEST = "jahia.csrf-guard.bypassForGuest";
     public static final String RESOLVED_URL_PATTERNS = "jahia.csrf-guard.resolvedUrlPatterns";
-    public static final String FETCH_METADATA_ENABLED = "jahia.csrf-guard.fetchMetadata.enabled";
+    public static final String CROSS_SITE_WRITE_PROTECTION_ENABLED = "jahia.csrf-guard.crossSiteWriteProtection.enabled";
 
     private Map<String, String> config = new HashMap<>();
     private boolean serviceEnabled = true;
@@ -51,7 +51,7 @@ public class JahiaCsrfGuardGlobalConfig {
     private String servletPath = "";
     private boolean bypassForGuest = true;
     private List<String> resolvedUrlPatterns = new ArrayList<>();
-    private boolean fetchMetadataEnabled = true;
+    private boolean crossSiteWriteProtectionEnabled = true;
 
     @Activate
     @Modified
@@ -65,7 +65,7 @@ public class JahiaCsrfGuardGlobalConfig {
         this.setResolvedUrlPatterns(config.getOrDefault(RESOLVED_URL_PATTERNS, "").isEmpty() ?
                 new ArrayList<>() :
                 List.of(config.get(RESOLVED_URL_PATTERNS).split(",")));
-        this.setFetchMetadataEnabled(config.getOrDefault(FETCH_METADATA_ENABLED, "true").equalsIgnoreCase("true"));
+        this.setCrossSiteWriteProtectionEnabled(config.getOrDefault(CROSS_SITE_WRITE_PROTECTION_ENABLED, "true").equalsIgnoreCase("true"));
         LOGGER.debug("Updated Jahia CSRF Guard Global configuration: {}", this);
     }
 
@@ -124,12 +124,12 @@ public class JahiaCsrfGuardGlobalConfig {
     /**
      * @return true when write requests are accepted only from the site's own browsing context
      */
-    public boolean isFetchMetadataEnabled() {
-        return fetchMetadataEnabled;
+    public boolean isCrossSiteWriteProtectionEnabled() {
+        return crossSiteWriteProtectionEnabled;
     }
 
-    public void setFetchMetadataEnabled(boolean fetchMetadataEnabled) {
-        this.fetchMetadataEnabled = fetchMetadataEnabled;
+    public void setCrossSiteWriteProtectionEnabled(boolean crossSiteWriteProtectionEnabled) {
+        this.crossSiteWriteProtectionEnabled = crossSiteWriteProtectionEnabled;
     }
 
     @Override public boolean equals(Object o) {
@@ -140,15 +140,15 @@ public class JahiaCsrfGuardGlobalConfig {
         JahiaCsrfGuardGlobalConfig that = (JahiaCsrfGuardGlobalConfig) o;
         return serviceEnabled == that.serviceEnabled && bypassForGuest == that.bypassForGuest && Objects.equals(servletAlias, that.servletAlias)
                 && Objects.equals(servletPath, that.servletPath) && Objects.equals(resolvedUrlPatterns, that.resolvedUrlPatterns)
-                && fetchMetadataEnabled == that.fetchMetadataEnabled;
+                && crossSiteWriteProtectionEnabled == that.crossSiteWriteProtectionEnabled;
     }
 
     @Override public int hashCode() {
-        return Objects.hash(serviceEnabled, servletAlias, servletPath, bypassForGuest, resolvedUrlPatterns, fetchMetadataEnabled);
+        return Objects.hash(serviceEnabled, servletAlias, servletPath, bypassForGuest, resolvedUrlPatterns, crossSiteWriteProtectionEnabled);
     }
 
     @Override public String toString() {
         return "JahiaCsrfGuardGlobalConfig{" + "enabled=" + serviceEnabled + ", servletPath='" + servletPath + '\'' + ", bypassForGuest="
-                + bypassForGuest + ", resolvedUrlPatterns=" + resolvedUrlPatterns + ", fetchMetadataEnabled=" + fetchMetadataEnabled + '}';
+                + bypassForGuest + ", resolvedUrlPatterns=" + resolvedUrlPatterns + ", crossSiteWriteProtectionEnabled=" + crossSiteWriteProtectionEnabled + '}';
     }
 }

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 /**
@@ -57,8 +58,8 @@ public class FetchMetadataFilter extends AbstractServletFilter {
     /** URLs reached from another site by design: an identity provider posts its assertion back to Jahia on *.saml */
     private static final List<Pattern> BUILT_IN_WHITELIST = Collections.singletonList(JahiaCsrfGuardConfig.createUrlPattern("*.saml"));
 
-    private volatile JahiaCsrfGuardGlobalConfig globalConfig;
-    private volatile Collection<JahiaCsrfGuardConfig> configs = new HashSet<>();
+    private final AtomicReference<JahiaCsrfGuardGlobalConfig> globalConfig = new AtomicReference<>();
+    private final AtomicReference<Collection<JahiaCsrfGuardConfig>> configs = new AtomicReference<>(new HashSet<>());
 
     @Activate
     public void activate() {
@@ -85,8 +86,10 @@ public class FetchMetadataFilter extends AbstractServletFilter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         if (isRejected(httpRequest)) {
-            LOGGER.warn("Rejected request (ip:{}, method:{}, uri:{}, {}:{})", httpRequest.getRemoteAddr(), httpRequest.getMethod(),
-                    httpRequest.getRequestURI(), SEC_FETCH_SITE_HEADER, httpRequest.getHeader(SEC_FETCH_SITE_HEADER));
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn("Rejected request (ip:{}, method:{}, uri:{}, {}:{})", httpRequest.getRemoteAddr(), httpRequest.getMethod(),
+                        httpRequest.getRequestURI(), SEC_FETCH_SITE_HEADER, httpRequest.getHeader(SEC_FETCH_SITE_HEADER));
+            }
             ((HttpServletResponse) response).sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }
@@ -94,7 +97,8 @@ public class FetchMetadataFilter extends AbstractServletFilter {
     }
 
     boolean isRejected(HttpServletRequest request) {
-        return globalConfig != null && globalConfig.isEnabled() && globalConfig.isFetchMetadataEnabled()
+        JahiaCsrfGuardGlobalConfig currentGlobalConfig = globalConfig.get();
+        return currentGlobalConfig != null && currentGlobalConfig.isEnabled() && currentGlobalConfig.isFetchMetadataEnabled()
                 && isCrossSite(request.getHeader(SEC_FETCH_SITE_HEADER))
                 && isWriteRequest(request)
                 && isFiltered(request) && !isWhiteListed(request);
@@ -159,8 +163,9 @@ public class FetchMetadataFilter extends AbstractServletFilter {
      * predate it.
      */
     private boolean isFiltered(ServletRequest request) {
-        return configs.stream().noneMatch(JahiaCsrfGuardConfig::hasFetchMetadataUrlPatterns)
-                || configs.stream().anyMatch(config -> config.isFetchMetadataFiltered(request));
+        Collection<JahiaCsrfGuardConfig> currentConfigs = configs.get();
+        return currentConfigs.stream().noneMatch(JahiaCsrfGuardConfig::hasFetchMetadataUrlPatterns)
+                || currentConfigs.stream().anyMatch(config -> config.isFetchMetadataFiltered(request));
     }
 
     /**
@@ -170,22 +175,22 @@ public class FetchMetadataFilter extends AbstractServletFilter {
     private boolean isWhiteListed(ServletRequest request) {
         String uri = ((HttpServletRequest) request).getRequestURI();
         return BUILT_IN_WHITELIST.stream().anyMatch(pattern -> pattern.matcher(uri).matches())
-                || configs.stream().anyMatch(config -> config.isFetchMetadataWhiteListed(request));
+                || configs.get().stream().anyMatch(config -> config.isFetchMetadataWhiteListed(request));
     }
 
     @Reference(service = JahiaCsrfGuardGlobalConfig.class, cardinality = ReferenceCardinality.MANDATORY, unbind = "-")
     public void setGlobalConfig(JahiaCsrfGuardGlobalConfig globalConfig) {
-        this.globalConfig = globalConfig;
+        this.globalConfig.set(globalConfig);
     }
 
     @Reference(service = JahiaCsrfGuardConfigFactory.class, policy = ReferencePolicy.DYNAMIC, bind = "setConfigs", unbind = "clearConfigs")
     public void setConfigs(JahiaCsrfGuardConfigFactory configFactory) {
         LOGGER.debug("Setting configurations from factory: {}", configFactory.getName());
-        this.configs = configFactory.getConfigs();
+        this.configs.set(configFactory.getConfigs());
     }
 
     public void clearConfigs(JahiaCsrfGuardConfigFactory configFactory) {
         LOGGER.debug("Clearing configurations from factory: {}", configFactory.getName());
-        this.configs = new HashSet<>();
+        this.configs.set(new HashSet<>());
     }
 }

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 /**
@@ -58,8 +57,11 @@ public class FetchMetadataFilter extends AbstractServletFilter {
     /** URLs reached from another site by design: an identity provider posts its assertion back to Jahia on *.saml */
     private static final List<Pattern> BUILT_IN_WHITELIST = Collections.singletonList(JahiaCsrfGuardConfig.createUrlPattern("*.saml"));
 
-    private final AtomicReference<JahiaCsrfGuardGlobalConfig> globalConfig = new AtomicReference<>();
-    private final AtomicReference<Collection<JahiaCsrfGuardConfig>> configs = new AtomicReference<>(new HashSet<>());
+    // volatile for safe cross-thread publication: configs is re-bound (DYNAMIC reference) while request threads read
+    // it, globalConfig is set once before activation. Every write is an unconditional assignment, so a plain volatile
+    // field is enough here (no compare-and-set) and keeps this filter consistent with CsrfGuardServletFilterWrapper.
+    private volatile JahiaCsrfGuardGlobalConfig globalConfig;
+    private volatile Collection<JahiaCsrfGuardConfig> configs = new HashSet<>();
 
     @Activate
     public void activate() {
@@ -87,8 +89,8 @@ public class FetchMetadataFilter extends AbstractServletFilter {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         if (isRejected(httpRequest)) {
             if (LOGGER.isWarnEnabled()) {
-                LOGGER.warn("Rejected request (ip:{}, method:{}, uri:{}, {}:{})", httpRequest.getRemoteAddr(), httpRequest.getMethod(),
-                        httpRequest.getRequestURI(), SEC_FETCH_SITE_HEADER, httpRequest.getHeader(SEC_FETCH_SITE_HEADER));
+                LOGGER.warn("Rejected request (ip:{}, method:{}, uri:{}, {}:{}, Origin:{})", httpRequest.getRemoteAddr(), httpRequest.getMethod(),
+                        httpRequest.getRequestURI(), SEC_FETCH_SITE_HEADER, httpRequest.getHeader(SEC_FETCH_SITE_HEADER), httpRequest.getHeader("Origin"));
             }
             ((HttpServletResponse) response).sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
@@ -97,7 +99,7 @@ public class FetchMetadataFilter extends AbstractServletFilter {
     }
 
     boolean isRejected(HttpServletRequest request) {
-        JahiaCsrfGuardGlobalConfig currentGlobalConfig = globalConfig.get();
+        JahiaCsrfGuardGlobalConfig currentGlobalConfig = globalConfig;
         return currentGlobalConfig != null && currentGlobalConfig.isEnabled() && currentGlobalConfig.isFetchMetadataEnabled()
                 && isCrossSite(request.getHeader(SEC_FETCH_SITE_HEADER))
                 && isWriteRequest(request)
@@ -136,6 +138,9 @@ public class FetchMetadataFilter extends AbstractServletFilter {
      * @return true when one of the values is a write method
      */
     static boolean queryStringAsksForWrite(String queryString) {
+        // read the raw query string, never request.getParameter(): getParameter() merges query and body parameters, so
+        // on a POST it parses the request body — which this early filter (order -1.0, ahead of the multi-read wrapper)
+        // must not consume — and freezes the character encoding, making a later setCharacterEncoding() a no-op.
         if (StringUtils.isEmpty(queryString)) {
             return false;
         }
@@ -163,7 +168,7 @@ public class FetchMetadataFilter extends AbstractServletFilter {
      * predate it.
      */
     private boolean isFiltered(ServletRequest request) {
-        Collection<JahiaCsrfGuardConfig> currentConfigs = configs.get();
+        Collection<JahiaCsrfGuardConfig> currentConfigs = configs;
         return currentConfigs.stream().noneMatch(JahiaCsrfGuardConfig::hasFetchMetadataUrlPatterns)
                 || currentConfigs.stream().anyMatch(config -> config.isFetchMetadataFiltered(request));
     }
@@ -175,22 +180,22 @@ public class FetchMetadataFilter extends AbstractServletFilter {
     private boolean isWhiteListed(ServletRequest request) {
         String uri = JahiaCsrfGuardConfig.normalizePath(((HttpServletRequest) request).getRequestURI());
         return BUILT_IN_WHITELIST.stream().anyMatch(pattern -> pattern.matcher(uri).matches())
-                || configs.get().stream().anyMatch(config -> config.isFetchMetadataWhiteListed(request));
+                || configs.stream().anyMatch(config -> config.isFetchMetadataWhiteListed(request));
     }
 
     @Reference(service = JahiaCsrfGuardGlobalConfig.class, cardinality = ReferenceCardinality.MANDATORY, unbind = "-")
     public void setGlobalConfig(JahiaCsrfGuardGlobalConfig globalConfig) {
-        this.globalConfig.set(globalConfig);
+        this.globalConfig = globalConfig;
     }
 
     @Reference(service = JahiaCsrfGuardConfigFactory.class, policy = ReferencePolicy.DYNAMIC, bind = "setConfigs", unbind = "clearConfigs")
     public void setConfigs(JahiaCsrfGuardConfigFactory configFactory) {
         LOGGER.debug("Setting configurations from factory: {}", configFactory.getName());
-        this.configs.set(configFactory.getConfigs());
+        this.configs = configFactory.getConfigs();
     }
 
     public void clearConfigs(JahiaCsrfGuardConfigFactory configFactory) {
         LOGGER.debug("Clearing configurations from factory: {}", configFactory.getName());
-        this.configs.set(new HashSet<>());
+        this.configs = new HashSet<>();
     }
 }

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
@@ -1,6 +1,7 @@
 package org.jahia.modules.jahiacsrfguard.filters;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jahia.bin.Render;
 import org.jahia.bin.filters.AbstractServletFilter;
 import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardConfig;
 import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardConfigFactory;
@@ -51,7 +52,6 @@ public class FetchMetadataFilter extends AbstractServletFilter {
 
     static final String SEC_FETCH_SITE_HEADER = "Sec-Fetch-Site";
     static final String CROSS_SITE = "cross-site";
-    static final String JCR_METHOD_TO_CALL = "jcrMethodToCall";
 
     private static final Set<String> WRITE_METHODS = new HashSet<>(Arrays.asList("POST", "PUT", "DELETE", "PATCH"));
 
@@ -147,7 +147,7 @@ public class FetchMetadataFilter extends AbstractServletFilter {
         }
         for (String pair : StringUtils.split(queryString, '&')) {
             String name = decode(StringUtils.substringBefore(pair, "="));
-            if (JCR_METHOD_TO_CALL.equals(name) && isWriteMethod(decode(StringUtils.substringAfter(pair, "=")))) {
+            if (Render.METHOD_TO_CALL.equals(name) && isWriteMethod(decode(StringUtils.substringAfter(pair, "=")))) {
                 return true;
             }
         }

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
@@ -1,0 +1,191 @@
+package org.jahia.modules.jahiacsrfguard.filters;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jahia.bin.filters.AbstractServletFilter;
+import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardConfig;
+import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardConfigFactory;
+import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardGlobalConfig;
+import org.osgi.service.component.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Applies the fetch metadata request policy: a request that writes content is served only when the browser reports
+ * it as originating from the site's own browsing context, i.e. the <code>Sec-Fetch-Site</code> request header is
+ * absent or holds anything other than <code>cross-site</code>.
+ * <p>
+ * A request writes content when its HTTP method is a write method, or when its query string supplies a
+ * <code>jcrMethodToCall</code> method Jahia acts upon in place of the HTTP method. The query string is read on its
+ * own so that the policy never triggers request body parsing, which the request encoding depends on.
+ * <p>
+ * The policy covers every URL except the ones it exempts itself, and both are configurable through the
+ * {@code fetchMetadataUrlPatterns} and {@code fetchMetadataWhitelist} properties of any
+ * {@code org.jahia.modules.jahiacsrfguard-*} configuration; {@code jahia.csrf-guard.fetchMetadata.enabled} drives the
+ * policy as a whole.
+ */
+@Component(immediate = true, service = AbstractServletFilter.class)
+public class FetchMetadataFilter extends AbstractServletFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FetchMetadataFilter.class);
+
+    static final String SEC_FETCH_SITE_HEADER = "Sec-Fetch-Site";
+    static final String CROSS_SITE = "cross-site";
+    static final String JCR_METHOD_TO_CALL = "jcrMethodToCall";
+
+    private static final Set<String> WRITE_METHODS = new HashSet<>(Arrays.asList("POST", "PUT", "DELETE", "PATCH"));
+
+    /** URLs reached from another site by design: an identity provider posts its assertion back to Jahia on *.saml */
+    private static final List<Pattern> BUILT_IN_WHITELIST = Collections.singletonList(JahiaCsrfGuardConfig.createUrlPattern("*.saml"));
+
+    private volatile JahiaCsrfGuardGlobalConfig globalConfig;
+    private volatile Collection<JahiaCsrfGuardConfig> configs = new HashSet<>();
+
+    @Activate
+    public void activate() {
+        LOGGER.debug("Activating Jahia CSRF Guard Fetch Metadata Filter");
+        setFilterName("Jahia CSRF Guard Fetch Metadata Filter");
+        setMatchAllUrls(true);
+        setUrlPatterns(new String[] { "/*" });
+        // decide on the incoming request, before it is dispatched further and before the error page it may lead to
+        setDispatcherTypes(Set.of(DispatcherType.REQUEST.name()));
+        setOrder(-1.0f);
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+        // nothing to initialize, the policy is driven by configuration
+    }
+
+    @Override
+    public void destroy() {
+        // nothing to release
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        if (isRejected(httpRequest)) {
+            LOGGER.warn("Rejected request (ip:{}, method:{}, uri:{}, {}:{})", httpRequest.getRemoteAddr(), httpRequest.getMethod(),
+                    httpRequest.getRequestURI(), SEC_FETCH_SITE_HEADER, httpRequest.getHeader(SEC_FETCH_SITE_HEADER));
+            ((HttpServletResponse) response).sendError(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
+        chain.doFilter(request, response);
+    }
+
+    boolean isRejected(HttpServletRequest request) {
+        return globalConfig != null && globalConfig.isEnabled() && globalConfig.isFetchMetadataEnabled()
+                && isCrossSite(request.getHeader(SEC_FETCH_SITE_HEADER))
+                && isWriteRequest(request)
+                && isFiltered(request) && !isWhiteListed(request);
+    }
+
+    /**
+     * @param secFetchSite value of the {@code Sec-Fetch-Site} request header
+     * @return true when the browser reports a cross-site initiator
+     */
+    static boolean isCrossSite(String secFetchSite) {
+        return CROSS_SITE.equalsIgnoreCase(StringUtils.trimToEmpty(secFetchSite));
+    }
+
+    /**
+     * @param request client request object for servlet
+     * @return true when the request writes content, by its HTTP method or by the method its query string asks Jahia to call
+     */
+    static boolean isWriteRequest(HttpServletRequest request) {
+        return isWriteMethod(request.getMethod()) || queryStringAsksForWrite(request.getQueryString());
+    }
+
+    /**
+     * @param method a method name
+     * @return true when the method writes content
+     */
+    static boolean isWriteMethod(String method) {
+        return WRITE_METHODS.contains(StringUtils.upperCase(StringUtils.trimToEmpty(method)));
+    }
+
+    /**
+     * Read the {@code jcrMethodToCall} values held by a query string. Names and values are decoded the way the
+     * container decodes them, and every occurrence counts, so that a value reaching Jahia is a value seen here.
+     *
+     * @param queryString the raw query string, may be null
+     * @return true when one of the values is a write method
+     */
+    static boolean queryStringAsksForWrite(String queryString) {
+        if (StringUtils.isEmpty(queryString)) {
+            return false;
+        }
+        for (String pair : StringUtils.split(queryString, '&')) {
+            String name = decode(StringUtils.substringBefore(pair, "="));
+            if (JCR_METHOD_TO_CALL.equals(name) && isWriteMethod(decode(StringUtils.substringAfter(pair, "=")))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String decode(String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException | IllegalArgumentException e) {
+            LOGGER.debug("Reading query string value as supplied: {}", value, e);
+            return value;
+        }
+    }
+
+    /**
+     * Check all url pattern configurations to see whether the policy applies to the current request. The policy covers
+     * every URL as long as no configuration sets a scope, so that it holds on an installation whose configuration files
+     * predate it.
+     */
+    private boolean isFiltered(ServletRequest request) {
+        return configs.stream().noneMatch(JahiaCsrfGuardConfig::hasFetchMetadataUrlPatterns)
+                || configs.stream().anyMatch(config -> config.isFetchMetadataFiltered(request));
+    }
+
+    /**
+     * Check all whitelist configurations, and the URLs exempted by the module itself, to see whether the policy is
+     * bypassed for the current request
+     */
+    private boolean isWhiteListed(ServletRequest request) {
+        String uri = ((HttpServletRequest) request).getRequestURI();
+        return BUILT_IN_WHITELIST.stream().anyMatch(pattern -> pattern.matcher(uri).matches())
+                || configs.stream().anyMatch(config -> config.isFetchMetadataWhiteListed(request));
+    }
+
+    @Reference(service = JahiaCsrfGuardGlobalConfig.class, cardinality = ReferenceCardinality.MANDATORY, unbind = "-")
+    public void setGlobalConfig(JahiaCsrfGuardGlobalConfig globalConfig) {
+        this.globalConfig = globalConfig;
+    }
+
+    @Reference(service = JahiaCsrfGuardConfigFactory.class, policy = ReferencePolicy.DYNAMIC, bind = "setConfigs", unbind = "clearConfigs")
+    public void setConfigs(JahiaCsrfGuardConfigFactory configFactory) {
+        LOGGER.debug("Setting configurations from factory: {}", configFactory.getName());
+        this.configs = configFactory.getConfigs();
+    }
+
+    public void clearConfigs(JahiaCsrfGuardConfigFactory configFactory) {
+        LOGGER.debug("Clearing configurations from factory: {}", configFactory.getName());
+        this.configs = new HashSet<>();
+    }
+}

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
@@ -39,8 +39,8 @@ import java.util.regex.Pattern;
  * own so that the policy never triggers request body parsing, which the request encoding depends on.
  * <p>
  * The policy covers every URL except the ones it exempts itself, and both are configurable through the
- * {@code fetchMetadataUrlPatterns} and {@code fetchMetadataWhitelist} properties of any
- * {@code org.jahia.modules.jahiacsrfguard-*} configuration; {@code jahia.csrf-guard.fetchMetadata.enabled} drives the
+ * {@code crossSiteWriteUrlPatterns} and {@code crossSiteWriteWhitelist} properties of any
+ * {@code org.jahia.modules.jahiacsrfguard-*} configuration; {@code jahia.csrf-guard.crossSiteWriteProtection.enabled} drives the
  * policy as a whole.
  */
 @Component(immediate = true, service = AbstractServletFilter.class)
@@ -100,7 +100,7 @@ public class FetchMetadataFilter extends AbstractServletFilter {
 
     boolean isRejected(HttpServletRequest request) {
         JahiaCsrfGuardGlobalConfig currentGlobalConfig = globalConfig;
-        return currentGlobalConfig != null && currentGlobalConfig.isEnabled() && currentGlobalConfig.isFetchMetadataEnabled()
+        return currentGlobalConfig != null && currentGlobalConfig.isEnabled() && currentGlobalConfig.isCrossSiteWriteProtectionEnabled()
                 && isCrossSite(request.getHeader(SEC_FETCH_SITE_HEADER))
                 && isWriteRequest(request)
                 && isFiltered(request) && !isWhiteListed(request);
@@ -169,8 +169,8 @@ public class FetchMetadataFilter extends AbstractServletFilter {
      */
     private boolean isFiltered(ServletRequest request) {
         Collection<JahiaCsrfGuardConfig> currentConfigs = configs;
-        return currentConfigs.stream().noneMatch(JahiaCsrfGuardConfig::hasFetchMetadataUrlPatterns)
-                || currentConfigs.stream().anyMatch(config -> config.isFetchMetadataFiltered(request));
+        return currentConfigs.stream().noneMatch(JahiaCsrfGuardConfig::hasCrossSiteWriteUrlPatterns)
+                || currentConfigs.stream().anyMatch(config -> config.isCrossSiteWriteFiltered(request));
     }
 
     /**
@@ -180,7 +180,7 @@ public class FetchMetadataFilter extends AbstractServletFilter {
     private boolean isWhiteListed(ServletRequest request) {
         String uri = JahiaCsrfGuardConfig.normalizePath(((HttpServletRequest) request).getRequestURI());
         return BUILT_IN_WHITELIST.stream().anyMatch(pattern -> pattern.matcher(uri).matches())
-                || configs.stream().anyMatch(config -> config.isFetchMetadataWhiteListed(request));
+                || configs.stream().anyMatch(config -> config.isCrossSiteWriteWhiteListed(request));
     }
 
     @Reference(service = JahiaCsrfGuardGlobalConfig.class, cardinality = ReferenceCardinality.MANDATORY, unbind = "-")

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 /**
@@ -57,11 +58,11 @@ public class FetchMetadataFilter extends AbstractServletFilter {
     /** URLs reached from another site by design: an identity provider posts its assertion back to Jahia on *.saml */
     private static final List<Pattern> BUILT_IN_WHITELIST = Collections.singletonList(JahiaCsrfGuardConfig.createUrlPattern("*.saml"));
 
-    // volatile for safe cross-thread publication: configs is re-bound (DYNAMIC reference) while request threads read
-    // it, globalConfig is set once before activation. Every write is an unconditional assignment, so a plain volatile
-    // field is enough here (no compare-and-set) and keeps this filter consistent with CsrfGuardServletFilterWrapper.
-    private volatile JahiaCsrfGuardGlobalConfig globalConfig;
-    private volatile Collection<JahiaCsrfGuardConfig> configs = new HashSet<>();
+    // AtomicReference (a thread-safe type) rather than a volatile reference: configs is re-bound (DYNAMIC reference)
+    // while request threads read it, globalConfig is set once before activation. A volatile non-primitive field
+    // publishes only the reference, not the referenced state, which Sonar flags (java:S3077).
+    private final AtomicReference<JahiaCsrfGuardGlobalConfig> globalConfig = new AtomicReference<>();
+    private final AtomicReference<Collection<JahiaCsrfGuardConfig>> configs = new AtomicReference<>(new HashSet<>());
 
     @Activate
     public void activate() {
@@ -99,7 +100,7 @@ public class FetchMetadataFilter extends AbstractServletFilter {
     }
 
     boolean isRejected(HttpServletRequest request) {
-        JahiaCsrfGuardGlobalConfig currentGlobalConfig = globalConfig;
+        JahiaCsrfGuardGlobalConfig currentGlobalConfig = globalConfig.get();
         return currentGlobalConfig != null && currentGlobalConfig.isEnabled() && currentGlobalConfig.isCrossSiteWriteProtectionEnabled()
                 && isCrossSite(request.getHeader(SEC_FETCH_SITE_HEADER))
                 && isWriteRequest(request)
@@ -168,7 +169,7 @@ public class FetchMetadataFilter extends AbstractServletFilter {
      * predate it.
      */
     private boolean isFiltered(ServletRequest request) {
-        Collection<JahiaCsrfGuardConfig> currentConfigs = configs;
+        Collection<JahiaCsrfGuardConfig> currentConfigs = configs.get();
         return currentConfigs.stream().noneMatch(JahiaCsrfGuardConfig::hasCrossSiteWriteUrlPatterns)
                 || currentConfigs.stream().anyMatch(config -> config.isCrossSiteWriteFiltered(request));
     }
@@ -180,22 +181,22 @@ public class FetchMetadataFilter extends AbstractServletFilter {
     private boolean isWhiteListed(ServletRequest request) {
         String uri = JahiaCsrfGuardConfig.normalizePath(((HttpServletRequest) request).getRequestURI());
         return BUILT_IN_WHITELIST.stream().anyMatch(pattern -> pattern.matcher(uri).matches())
-                || configs.stream().anyMatch(config -> config.isCrossSiteWriteWhiteListed(request));
+                || configs.get().stream().anyMatch(config -> config.isCrossSiteWriteWhiteListed(request));
     }
 
     @Reference(service = JahiaCsrfGuardGlobalConfig.class, cardinality = ReferenceCardinality.MANDATORY, unbind = "-")
     public void setGlobalConfig(JahiaCsrfGuardGlobalConfig globalConfig) {
-        this.globalConfig = globalConfig;
+        this.globalConfig.set(globalConfig);
     }
 
     @Reference(service = JahiaCsrfGuardConfigFactory.class, policy = ReferencePolicy.DYNAMIC, bind = "setConfigs", unbind = "clearConfigs")
     public void setConfigs(JahiaCsrfGuardConfigFactory configFactory) {
         LOGGER.debug("Setting configurations from factory: {}", configFactory.getName());
-        this.configs = configFactory.getConfigs();
+        this.configs.set(configFactory.getConfigs());
     }
 
     public void clearConfigs(JahiaCsrfGuardConfigFactory configFactory) {
         LOGGER.debug("Clearing configurations from factory: {}", configFactory.getName());
-        this.configs = new HashSet<>();
+        this.configs.set(new HashSet<>());
     }
 }

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
@@ -173,7 +173,7 @@ public class FetchMetadataFilter extends AbstractServletFilter {
      * bypassed for the current request
      */
     private boolean isWhiteListed(ServletRequest request) {
-        String uri = ((HttpServletRequest) request).getRequestURI();
+        String uri = JahiaCsrfGuardConfig.normalizePath(((HttpServletRequest) request).getRequestURI());
         return BUILT_IN_WHITELIST.stream().anyMatch(pattern -> pattern.matcher(uri).matches())
                 || configs.get().stream().anyMatch(config -> config.isFetchMetadataWhiteListed(request));
     }

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard-default.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard-default.cfg
@@ -6,5 +6,5 @@ whitelist = *.myAction.do
 # fetch metadata request policy: the URLs it covers, and the URLs reached from another site by design.
 # These are the values the module applies on its own, restate them here only to narrow the scope or to
 # exempt a URL in addition to the SAML callback the module always exempts.
-# fetchMetadataUrlPatterns = /*
-# fetchMetadataWhitelist = *.saml
+# crossSiteWriteUrlPatterns = /*
+# crossSiteWriteWhitelist = *.saml

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard-default.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard-default.cfg
@@ -2,3 +2,9 @@
 
 urlPatterns = *.do, */\\\\*
 whitelist = *.myAction.do
+
+# fetch metadata request policy: the URLs it covers, and the URLs reached from another site by design.
+# These are the values the module applies on its own, restate them here only to narrow the scope or to
+# exempt a URL in addition to the SAML callback the module always exempts.
+# fetchMetadataUrlPatterns = /*
+# fetchMetadataWhitelist = *.saml

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard.global.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard.global.cfg
@@ -2,3 +2,4 @@ jahia.csrf-guard.enabled = true
 jahia.csrf-guard.servletAlias = /CsrfServlet
 jahia.csrf-guard.bypassForGuest = true
 jahia.csrf-guard.resolvedUrlPatterns = *.jsp,*.html,*.htm
+jahia.csrf-guard.fetchMetadata.enabled = true

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard.global.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard.global.cfg
@@ -2,4 +2,4 @@ jahia.csrf-guard.enabled = true
 jahia.csrf-guard.servletAlias = /CsrfServlet
 jahia.csrf-guard.bypassForGuest = true
 jahia.csrf-guard.resolvedUrlPatterns = *.jsp,*.html,*.htm
-jahia.csrf-guard.fetchMetadata.enabled = true
+jahia.csrf-guard.crossSiteWriteProtection.enabled = true

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfigTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfigTest.java
@@ -1,0 +1,59 @@
+package org.jahia.modules.jahiacsrfguard;
+
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the matrix-parameter normalization that {@link JahiaCsrfGuardConfig#matches} now applies. Because the existing
+ * token filter's {@code isFiltered}/{@code isWhiteListed} route through the same helper, this normalization also shifts
+ * their matching — a matrix-param URI is matched on the path Jahia resolves, not on the raw request URI.
+ */
+public class JahiaCsrfGuardConfigTest {
+
+    @Test
+    public void normalizePathStripsMatrixParametersPerSegment() {
+        assertEquals("/home.html", JahiaCsrfGuardConfig.normalizePath("/home.html;x=.saml"));
+        assertEquals("/a/b/c", JahiaCsrfGuardConfig.normalizePath("/a;p=1/b;q=2/c"));
+        assertEquals("/home/", JahiaCsrfGuardConfig.normalizePath("/home/"));
+        assertEquals("/a/", JahiaCsrfGuardConfig.normalizePath("/a;jsessionid=xyz/"));
+        assertEquals("", JahiaCsrfGuardConfig.normalizePath(null));
+    }
+
+    @Test
+    public void urlPatternMatchingNormalizesMatrixParameters() {
+        JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.URL_PATTERNS, "*.do");
+        // a matrix parameter no longer hides the .do suffix the pattern selects
+        assertTrue(config.isFiltered(request("/home.logAction.do;jsessionid=abc")));
+        assertTrue(config.isFiltered(request("/home.logAction.do")));
+    }
+
+    @Test
+    public void whitelistMatchingCannotBeForgedByAMatrixParameter() {
+        JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.WHITELIST, "*.saml");
+        // a request Jahia resolves to /home.html must not borrow the *.saml exemption through a matrix parameter
+        assertFalse(config.isWhiteListed(request("/sites/site/home.html;x=.saml")));
+        assertTrue(config.isWhiteListed(request("/sites/site/home.callback.saml")));
+        assertTrue(config.isWhiteListed(request("/sites/site/home.callback.saml;jsessionid=abc")));
+    }
+
+    private static JahiaCsrfGuardConfig config(String property, String value) {
+        Dictionary<String, Object> properties = new Hashtable<>();
+        properties.put(property, value);
+        return JahiaCsrfGuardConfig.build("org.jahia.modules.jahiacsrfguard-test", properties);
+    }
+
+    private static HttpServletRequest request(String uri) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn(uri);
+        return request;
+    }
+}

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
@@ -154,7 +154,7 @@ public class FetchMetadataFilterTest {
 
     @Test
     public void policyOffServesEverything() {
-        filter.setGlobalConfig(globalConfig(Map.of(JahiaCsrfGuardGlobalConfig.FETCH_METADATA_ENABLED, "false")));
+        filter.setGlobalConfig(globalConfig(Map.of(JahiaCsrfGuardGlobalConfig.CROSS_SITE_WRITE_PROTECTION_ENABLED, "false")));
         assertFalse(filter.isRejected(request("POST", RENDER_URI, null, "cross-site")));
     }
 
@@ -197,10 +197,10 @@ public class FetchMetadataFilterTest {
     private static JahiaCsrfGuardConfigFactory configFactory(String urlPatterns, String whitelist) {
         Dictionary<String, Object> properties = new Hashtable<>();
         if (urlPatterns != null) {
-            properties.put(JahiaCsrfGuardConfig.FETCH_METADATA_URL_PATTERNS, urlPatterns);
+            properties.put(JahiaCsrfGuardConfig.CROSS_SITE_WRITE_URL_PATTERNS, urlPatterns);
         }
         if (whitelist != null) {
-            properties.put(JahiaCsrfGuardConfig.FETCH_METADATA_WHITELIST, whitelist);
+            properties.put(JahiaCsrfGuardConfig.CROSS_SITE_WRITE_WHITELIST, whitelist);
         }
         JahiaCsrfGuardConfigFactory factory = new JahiaCsrfGuardConfigFactory();
         try {

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
@@ -135,6 +135,17 @@ public class FetchMetadataFilterTest {
     }
 
     @Test
+    public void matrixParameterCannotForgeAWhitelistedUrl() {
+        // /home.html ends in .saml only through a matrix parameter Jahia's Render dispatch drops before writing home.html
+        assertTrue(filter.isRejected(request("POST", "/sites/site/home.html;x=.saml", "jcrMethodToCall=put", "cross-site")));
+    }
+
+    @Test
+    public void matrixParameterDoesNotHideAGenuinelyWhitelistedUrl() {
+        assertFalse(filter.isRejected(request("POST", "/sites/site/home.callback.saml;jsessionid=abc", null, "cross-site")));
+    }
+
+    @Test
     public void urlOutOfScopeIsServed() {
         filter.setConfigs(configFactory("/cms/*", null));
         assertTrue(filter.isRejected(request("POST", "/cms/render/live/fr/home", null, "cross-site")));

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
@@ -1,0 +1,202 @@
+package org.jahia.modules.jahiacsrfguard.filters;
+
+import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardConfig;
+import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardConfigFactory;
+import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardGlobalConfig;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FetchMetadataFilterTest {
+
+    private static final String RENDER_URI = "/fr/users/root";
+
+    private FetchMetadataFilter filter;
+
+    @Before
+    public void setUp() {
+        filter = new FetchMetadataFilter();
+        filter.setGlobalConfig(globalConfig(Map.of()));
+        filter.setConfigs(configFactory("/*", "*.saml"));
+    }
+
+    // --- Sec-Fetch-Site reading -------------------------------------------------------------------------------------
+
+    @Test
+    public void crossSiteIsRecognized() {
+        assertTrue(FetchMetadataFilter.isCrossSite("cross-site"));
+        assertTrue(FetchMetadataFilter.isCrossSite("Cross-Site"));
+        assertTrue(FetchMetadataFilter.isCrossSite(" cross-site "));
+    }
+
+    @Test
+    public void otherSiteValuesAreNotCrossSite() {
+        assertFalse(FetchMetadataFilter.isCrossSite("same-origin"));
+        assertFalse(FetchMetadataFilter.isCrossSite("same-site"));
+        assertFalse(FetchMetadataFilter.isCrossSite("none"));
+        assertFalse(FetchMetadataFilter.isCrossSite(""));
+        assertFalse(FetchMetadataFilter.isCrossSite(null));
+    }
+
+    // --- write detection --------------------------------------------------------------------------------------------
+
+    @Test
+    public void writeMethodsAreRecognized() {
+        assertTrue(FetchMetadataFilter.isWriteMethod("POST"));
+        assertTrue(FetchMetadataFilter.isWriteMethod("PUT"));
+        assertTrue(FetchMetadataFilter.isWriteMethod("DELETE"));
+        assertTrue(FetchMetadataFilter.isWriteMethod("PATCH"));
+        assertTrue(FetchMetadataFilter.isWriteMethod("put"));
+        assertTrue(FetchMetadataFilter.isWriteMethod(" Put "));
+    }
+
+    @Test
+    public void readMethodsAreNotWriteMethods() {
+        assertFalse(FetchMetadataFilter.isWriteMethod("GET"));
+        assertFalse(FetchMetadataFilter.isWriteMethod("HEAD"));
+        assertFalse(FetchMetadataFilter.isWriteMethod("OPTIONS"));
+        assertFalse(FetchMetadataFilter.isWriteMethod(""));
+        assertFalse(FetchMetadataFilter.isWriteMethod(null));
+    }
+
+    @Test
+    public void queryStringMethodIsRead() {
+        assertTrue(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall=put"));
+        assertTrue(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall=PUT"));
+        assertTrue(FetchMetadataFilter.queryStringAsksForWrite("a=1&jcrMethodToCall=delete&b=2"));
+        assertTrue(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall=get&jcrMethodToCall=put"));
+    }
+
+    @Test
+    public void percentEncodedQueryStringMethodIsRead() {
+        assertTrue(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall=%70ut"));
+        assertTrue(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodTo%43all=put"));
+    }
+
+    @Test
+    public void queryStringWithoutWriteMethodIsRead() {
+        assertFalse(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall=get"));
+        assertFalse(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall="));
+        assertFalse(FetchMetadataFilter.queryStringAsksForWrite("otherParam=put"));
+        assertFalse(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCallSuffix=put"));
+        assertFalse(FetchMetadataFilter.queryStringAsksForWrite(""));
+        assertFalse(FetchMetadataFilter.queryStringAsksForWrite(null));
+    }
+
+    @Test
+    public void valuesThatDoNotDecodeAreReadAsSupplied() {
+        assertTrue(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall=put&jcrMethodToCall=%zz"));
+        assertFalse(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall=put%"));
+        assertFalse(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall=%zz"));
+    }
+
+    // --- the policy -------------------------------------------------------------------------------------------------
+
+    @Test
+    public void crossSitePostIsRejected() {
+        assertTrue(filter.isRejected(request("POST", RENDER_URI, null, "cross-site")));
+    }
+
+    @Test
+    public void crossSiteGetSupplyingAWriteMethodIsRejected() {
+        assertTrue(filter.isRejected(request("GET", RENDER_URI, "jcrMethodToCall=put&j:title=x", "cross-site")));
+    }
+
+    @Test
+    public void crossSiteActionPostIsRejected() {
+        assertTrue(filter.isRejected(request("POST", "/en/sites/site/home.logAction.do", null, "cross-site")));
+    }
+
+    @Test
+    public void crossSiteGetIsServed() {
+        assertFalse(filter.isRejected(request("GET", RENDER_URI, null, "cross-site")));
+    }
+
+    @Test
+    public void sameSiteWriteIsServed() {
+        assertFalse(filter.isRejected(request("POST", RENDER_URI, null, "same-site")));
+        assertFalse(filter.isRejected(request("POST", RENDER_URI, null, "same-origin")));
+        assertFalse(filter.isRejected(request("POST", RENDER_URI, null, "none")));
+        assertFalse(filter.isRejected(request("PUT", RENDER_URI, null, null)));
+    }
+
+    @Test
+    public void whitelistedUrlIsServed() {
+        assertFalse(filter.isRejected(request("POST", "/sites/site/home.callback.saml", null, "cross-site")));
+    }
+
+    @Test
+    public void urlOutOfScopeIsServed() {
+        filter.setConfigs(configFactory("/cms/*", null));
+        assertTrue(filter.isRejected(request("POST", "/cms/render/live/fr/home", null, "cross-site")));
+        assertFalse(filter.isRejected(request("POST", RENDER_URI, null, "cross-site")));
+    }
+
+    @Test
+    public void policyOffServesEverything() {
+        filter.setGlobalConfig(globalConfig(Map.of(JahiaCsrfGuardGlobalConfig.FETCH_METADATA_ENABLED, "false")));
+        assertFalse(filter.isRejected(request("POST", RENDER_URI, null, "cross-site")));
+    }
+
+    @Test
+    public void moduleOffServesEverything() {
+        filter.setGlobalConfig(globalConfig(Map.of(JahiaCsrfGuardGlobalConfig.ENABLED, "false")));
+        assertFalse(filter.isRejected(request("POST", RENDER_URI, null, "cross-site")));
+    }
+
+    @Test
+    public void withoutConfigurationThePolicyCoversEveryUrl() {
+        filter.clearConfigs(mock(JahiaCsrfGuardConfigFactory.class));
+        assertTrue(filter.isRejected(request("POST", RENDER_URI, null, "cross-site")));
+        assertTrue(filter.isRejected(request("POST", "/cms/render/live/fr/home", null, "cross-site")));
+    }
+
+    @Test
+    public void withoutConfigurationTheSamlCallbackIsServed() {
+        filter.clearConfigs(mock(JahiaCsrfGuardConfigFactory.class));
+        assertFalse(filter.isRejected(request("POST", "/sites/site/home.callback.saml", null, "cross-site")));
+    }
+
+    // --- fixtures ---------------------------------------------------------------------------------------------------
+
+    private static HttpServletRequest request(String method, String uri, String queryString, String secFetchSite) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn(method);
+        when(request.getRequestURI()).thenReturn(uri);
+        when(request.getQueryString()).thenReturn(queryString);
+        when(request.getHeader(FetchMetadataFilter.SEC_FETCH_SITE_HEADER)).thenReturn(secFetchSite);
+        return request;
+    }
+
+    private static JahiaCsrfGuardGlobalConfig globalConfig(Map<String, String> properties) {
+        JahiaCsrfGuardGlobalConfig config = new JahiaCsrfGuardGlobalConfig();
+        config.modified(properties);
+        return config;
+    }
+
+    private static JahiaCsrfGuardConfigFactory configFactory(String urlPatterns, String whitelist) {
+        Dictionary<String, Object> properties = new Hashtable<>();
+        if (urlPatterns != null) {
+            properties.put(JahiaCsrfGuardConfig.FETCH_METADATA_URL_PATTERNS, urlPatterns);
+        }
+        if (whitelist != null) {
+            properties.put(JahiaCsrfGuardConfig.FETCH_METADATA_WHITELIST, whitelist);
+        }
+        JahiaCsrfGuardConfigFactory factory = new JahiaCsrfGuardConfigFactory();
+        try {
+            factory.updated("org.jahia.modules.jahiacsrfguard-test", properties);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        return factory;
+    }
+}

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
 
 public class FetchMetadataFilterTest {
 
-    private static final String RENDER_URI = "/fr/users/root";
+    private static final String RENDER_URI = "/en/sites/mysite/home";
 
     private FetchMetadataFilter filter;
 

--- a/tests/cypress/e2e/fetchMetadata.cy.ts
+++ b/tests/cypress/e2e/fetchMetadata.cy.ts
@@ -1,5 +1,5 @@
 import {addNode, createSite, deleteSite, publishAndWaitJobEnding} from '@jahia/cypress';
-import {updateCsrfGuardFetchMetadataEnabled} from '../utils/utils';
+import {updateCsrfGuardFetchMetadataWhiteList} from '../utils/utils';
 
 describe('Fetch metadata request policy tests', () => {
     const targetSiteKey = 'csrfGuardSite';
@@ -90,6 +90,35 @@ describe('Fetch metadata request policy tests', () => {
         }).its('status').should('equal', 403);
     });
 
+    // The policy keys on the request shape, not on what the request writes: a content-creation request
+    // through the render pipeline is served or refused on the same terms as any other write, whatever
+    // node type it carries.
+    const createChildUrl = '/cms/render/default/en/sites/' + targetSiteKey + '/home/pagecontent';
+
+    it('should serve a content-creation request reported as same-origin', () => {
+        cy.request({
+            method: 'POST',
+            url: createChildUrl,
+            form: true,
+            body: {jcrNodeType: 'jnt:contentList', nodeName: 'sameOriginChild'},
+            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'same-origin'},
+            followRedirect: false,
+            failOnStatusCode: false
+        }).its('status').should('be.oneOf', [200, 201, 303]);
+    });
+
+    it('should reject a cross-site content-creation request whatever node type it carries', () => {
+        cy.request({
+            method: 'POST',
+            url: createChildUrl,
+            form: true,
+            body: {jcrNodeType: 'jnt:contentList', nodeName: 'crossSiteChild'},
+            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'cross-site'},
+            followRedirect: false,
+            failOnStatusCode: false
+        }).its('status').should('equal', 403);
+    });
+
     it('should serve a cross-site read request', () => {
         cy.request({
             method: 'GET',
@@ -99,15 +128,15 @@ describe('Fetch metadata request policy tests', () => {
         }).its('status').should('equal', 200);
     });
 
-    it('should follow the configuration switch', () => {
-        updateCsrfGuardFetchMetadataEnabled(false);
+    it('should exempt a whitelisted url and cover it again once removed', () => {
+        updateCsrfGuardFetchMetadataWhiteList('*.logAction.do');
         crossSiteWriteEventuallyAnswers(200);
-        updateCsrfGuardFetchMetadataEnabled(true);
+        updateCsrfGuardFetchMetadataWhiteList('*.notAnAction.do');
         crossSiteWriteEventuallyAnswers(403);
     });
 
     after('Clean', () => {
-        updateCsrfGuardFetchMetadataEnabled(true);
+        updateCsrfGuardFetchMetadataWhiteList('*.notAnAction.do');
         deleteSite(targetSiteKey);
     });
 });

--- a/tests/cypress/e2e/fetchMetadata.cy.ts
+++ b/tests/cypress/e2e/fetchMetadata.cy.ts
@@ -1,5 +1,5 @@
 import {addNode, createSite, deleteSite, publishAndWaitJobEnding} from '@jahia/cypress';
-import {updateCsrfGuardFetchMetadataWhiteList} from '../utils/utils';
+import {updateCsrfGuardCrossSiteWriteWhiteList} from '../utils/utils';
 
 describe('Fetch metadata request policy tests', () => {
     const targetSiteKey = 'csrfGuardSite';
@@ -129,14 +129,14 @@ describe('Fetch metadata request policy tests', () => {
     });
 
     it('should exempt a whitelisted url and cover it again once removed', () => {
-        updateCsrfGuardFetchMetadataWhiteList('*.logAction.do');
+        updateCsrfGuardCrossSiteWriteWhiteList('*.logAction.do');
         crossSiteWriteEventuallyAnswers(200);
-        updateCsrfGuardFetchMetadataWhiteList('*.notAnAction.do');
+        updateCsrfGuardCrossSiteWriteWhiteList('*.notAnAction.do');
         crossSiteWriteEventuallyAnswers(403);
     });
 
     after('Clean', () => {
-        updateCsrfGuardFetchMetadataWhiteList('*.notAnAction.do');
+        updateCsrfGuardCrossSiteWriteWhiteList('*.notAnAction.do');
         deleteSite(targetSiteKey);
     });
 });

--- a/tests/cypress/e2e/fetchMetadata.cy.ts
+++ b/tests/cypress/e2e/fetchMetadata.cy.ts
@@ -1,0 +1,102 @@
+import {addNode, createSite, deleteSite, publishAndWaitJobEnding} from '@jahia/cypress';
+import {updateCsrfGuardFetchMetadataEnabled} from '../utils/utils';
+
+describe('Fetch metadata request policy tests', () => {
+    const targetSiteKey = 'csrfGuardSite';
+    const actionUrl = '/en/sites/' + targetSiteKey + '/home.logAction.do';
+    const pageUrl = '/en/sites/' + targetSiteKey + '/home.html';
+
+    before('Create target test site', () => {
+        cy.log('Create site ' + targetSiteKey + ' for csrf tests');
+        createSite(targetSiteKey, {locale: 'en', templateSet: 'jahia-csrf-guard-test-module', serverName: 'localhost'});
+        addNode({
+            parentPathOrId: `/sites/${targetSiteKey}/home`,
+            primaryNodeType: 'jnt:contentList',
+            name: 'pagecontent'
+        }).then(() => {
+            addNode({
+                parentPathOrId: `/sites/${targetSiteKey}/home/pagecontent`,
+                primaryNodeType: 'csrf:testContent',
+                name: 'test-content',
+                mixins: ['jmix:renderable']
+            }).then(() => {
+                publishAndWaitJobEnding('/sites/' + targetSiteKey + '/home');
+            });
+        });
+    });
+
+    beforeEach(() => {
+        cy.login();
+    });
+
+    afterEach(() => {
+        cy.logout();
+    });
+
+    it('should serve a write request reported as same-origin', () => {
+        cy.request({
+            method: 'POST',
+            url: actionUrl,
+            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'same-origin'},
+            failOnStatusCode: true
+        }).its('status').should('equal', 200);
+    });
+
+    it('should serve a write request when the header is absent', () => {
+        cy.request({
+            method: 'POST',
+            url: actionUrl,
+            headers: {Origin: Cypress.config().baseUrl},
+            failOnStatusCode: true
+        }).its('status').should('equal', 200);
+    });
+
+    it('should reject a write request reported as cross-site', () => {
+        cy.request({
+            method: 'POST',
+            url: actionUrl,
+            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'cross-site'},
+            failOnStatusCode: false
+        }).its('status').should('equal', 403);
+    });
+
+    it('should reject a cross-site request asking for a write method', () => {
+        cy.request({
+            method: 'GET',
+            url: pageUrl + '?jcrMethodToCall=put',
+            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'cross-site'},
+            failOnStatusCode: false
+        }).its('status').should('equal', 403);
+    });
+
+    it('should serve a cross-site read request', () => {
+        cy.request({
+            method: 'GET',
+            url: pageUrl,
+            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'cross-site'},
+            failOnStatusCode: true
+        }).its('status').should('equal', 200);
+    });
+
+    it('should serve a write request reported as cross-site once the policy is turned off', () => {
+        updateCsrfGuardFetchMetadataEnabled(false);
+        cy.request({
+            method: 'POST',
+            url: actionUrl,
+            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'cross-site'},
+            failOnStatusCode: true
+        }).its('status').should('equal', 200);
+        updateCsrfGuardFetchMetadataEnabled(true);
+        cy.request({
+            method: 'POST',
+            url: actionUrl,
+            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'cross-site'},
+            failOnStatusCode: false
+        }).its('status').should('equal', 403);
+    });
+
+    after('Clean', () => {
+        updateCsrfGuardFetchMetadataEnabled(true);
+        deleteSite(targetSiteKey);
+    });
+});

--- a/tests/cypress/e2e/fetchMetadata.cy.ts
+++ b/tests/cypress/e2e/fetchMetadata.cy.ts
@@ -33,6 +33,27 @@ describe('Fetch metadata request policy tests', () => {
         cy.logout();
     });
 
+    /**
+     * Repeat the request until it answers the expected status: a configuration change reaches the module through its
+     * configuration file, which is read at its own pace.
+     */
+    const crossSiteWriteEventuallyAnswers = (expectedStatus: number, remainingAttempts = 25) => {
+        cy.request({
+            method: 'POST',
+            url: actionUrl,
+            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'cross-site'},
+            failOnStatusCode: false
+        }).then(response => {
+            if (response.status === expectedStatus || remainingAttempts === 0) {
+                expect(response.status).to.equal(expectedStatus);
+            } else {
+                // eslint-disable-next-line cypress/no-unnecessary-waiting
+                cy.wait(2000);
+                crossSiteWriteEventuallyAnswers(expectedStatus, remainingAttempts - 1);
+            }
+        });
+    };
+
     it('should serve a write request reported as same-origin', () => {
         cy.request({
             method: 'POST',
@@ -78,21 +99,11 @@ describe('Fetch metadata request policy tests', () => {
         }).its('status').should('equal', 200);
     });
 
-    it('should serve a write request reported as cross-site once the policy is turned off', () => {
+    it('should follow the configuration switch', () => {
         updateCsrfGuardFetchMetadataEnabled(false);
-        cy.request({
-            method: 'POST',
-            url: actionUrl,
-            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'cross-site'},
-            failOnStatusCode: true
-        }).its('status').should('equal', 200);
+        crossSiteWriteEventuallyAnswers(200);
         updateCsrfGuardFetchMetadataEnabled(true);
-        cy.request({
-            method: 'POST',
-            url: actionUrl,
-            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'cross-site'},
-            failOnStatusCode: false
-        }).its('status').should('equal', 403);
+        crossSiteWriteEventuallyAnswers(403);
     });
 
     after('Clean', () => {

--- a/tests/cypress/utils/utils.ts
+++ b/tests/cypress/utils/utils.ts
@@ -22,12 +22,12 @@ export const updateCsrfGuardWhiteListConfig = (whitelist?: string) => {
     }
 };
 
-export const updateCsrfGuardFetchMetadataWhiteList = (whitelist: string) => {
+export const updateCsrfGuardCrossSiteWriteWhiteList = (whitelist: string) => {
     const conf = {
         editConfiguration: 'org.jahia.modules.jahiacsrfguard-dummy',
         configIdentifier: 'global',
         properties: {
-            fetchMetadataWhitelist: whitelist
+            crossSiteWriteWhitelist: whitelist
         }
     };
 

--- a/tests/cypress/utils/utils.ts
+++ b/tests/cypress/utils/utils.ts
@@ -27,7 +27,7 @@ export const updateCsrfGuardFetchMetadataEnabled = (enabled: boolean) => {
         editConfiguration: 'org.jahia.modules.jahiacsrfguard.global',
         configIdentifier: 'global',
         properties: {
-            'jahia.csrf-guard.fetchMetadata.enabled': enabled
+            'jahia.csrf-guard.fetchMetadata.enabled': String(enabled)
         }
     };
 
@@ -47,7 +47,7 @@ export const updateCsrfGuardBypassGuest = (bypass: boolean) => {
         editConfiguration: 'org.jahia.modules.jahiacsrfguard.global',
         configIdentifier: 'global',
         properties: {
-            'jahia.csrf-guard.bypassForGuest': bypass
+            'jahia.csrf-guard.bypassForGuest': String(bypass)
         }
     };
 

--- a/tests/cypress/utils/utils.ts
+++ b/tests/cypress/utils/utils.ts
@@ -22,12 +22,12 @@ export const updateCsrfGuardWhiteListConfig = (whitelist?: string) => {
     }
 };
 
-export const updateCsrfGuardFetchMetadataEnabled = (enabled: boolean) => {
+export const updateCsrfGuardFetchMetadataWhiteList = (whitelist: string) => {
     const conf = {
-        editConfiguration: 'org.jahia.modules.jahiacsrfguard.global',
+        editConfiguration: 'org.jahia.modules.jahiacsrfguard-dummy',
         configIdentifier: 'global',
         properties: {
-            'jahia.csrf-guard.fetchMetadata.enabled': String(enabled)
+            fetchMetadataWhitelist: whitelist
         }
     };
 

--- a/tests/cypress/utils/utils.ts
+++ b/tests/cypress/utils/utils.ts
@@ -22,6 +22,26 @@ export const updateCsrfGuardWhiteListConfig = (whitelist?: string) => {
     }
 };
 
+export const updateCsrfGuardFetchMetadataEnabled = (enabled: boolean) => {
+    const conf = {
+        editConfiguration: 'org.jahia.modules.jahiacsrfguard.global',
+        configIdentifier: 'global',
+        properties: {
+            'jahia.csrf-guard.fetchMetadata.enabled': enabled
+        }
+    };
+
+    cy.runProvisioningScript({fileContent: JSON.stringify([conf]), type: 'application/json'}, null);
+    if (Cypress.env('JAHIA_CLUSTER_ENABLED')) {
+        // Wait to allow to synchronize in cluster
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(20000);
+    } else {
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(10000);
+    }
+};
+
 export const updateCsrfGuardBypassGuest = (bypass: boolean) => {
     const conf = {
         editConfiguration: 'org.jahia.modules.jahiacsrfguard.global',


### PR DESCRIPTION
## Summary

Browsers state the initiator of every request in the `Sec-Fetch-Site` header, and a page cannot alter it. This adds that signal to the module: a request that writes content is served when the browser reports the site's own browsing context (`same-origin`, `same-site`), when the user started it themselves (`none`), or when the header is absent — and answered `403` when the browser reports `cross-site`.

Token validation is untouched. Reading a header needs no token in the page, so the policy also holds for the clients the page script never reaches.

## Change

- `FetchMetadataFilter` — a servlet filter, ordered ahead of the token filter and running on `REQUEST` only, that answers `403` to a write request the browser reports as `cross-site`. A request writes content when its HTTP method is `POST`, `PUT`, `DELETE` or `PATCH`, or when its query string asks Jahia to act upon one of those through `jcrMethodToCall`. The query string is read on its own, so the filter never triggers request body parsing — the request encoding depends on it.
- Scope and exemptions come from `fetchMetadataUrlPatterns` and `fetchMetadataWhitelist` on any module configuration, compiled by the same `createUrlPattern` as the existing `urlPatterns` and `whitelist`. The module applies the defaults itself — every URL in scope, the SAML callback (`*.saml`) exempt — so the policy holds on an installation whose `-default.cfg` was written by an earlier version, since that file is kept as it is on upgrade.
- The policy as a whole follows a new `fetchMetadata.enabled` property of the module's global configuration (default `true`), and the module's own switch keeps the last word.
- Academy documentation and a changelog fragment.

## Verification

`FetchMetadataFilterTest` — 19 cases over the header values, the write methods, query-string reading (percent-encoded names and values, repeated parameters, values that do not decode), the scope, the whitelist and both switches.

On a running Jahia 8.2 with the module deployed, writing a property through a render URL as `root`:

| request | result |
|---|---|
| `POST …/node?jcrMethodToCall=put` + `Sec-Fetch-Site: cross-site` | `403`, property unchanged |
| the same with `Sec-Fetch-Site: same-origin` | `200`, property written |
| the same with no `Sec-Fetch-Site` header | `200`, property written |
| `GET …/home.html` + `Sec-Fetch-Site: cross-site` | `200` |
| `GET …/node?jcrMethodToCall=put` + `Sec-Fetch-Site: cross-site` | `403` |

The bundle re-activates cleanly, both filters register, and a `403` still renders the standard error page.

`tests/cypress/e2e/fetchMetadata.cy.ts` covers the same matrix in CI, and asserts the policy follows its configuration switch.
