### PR TITLE
fix: serve write requests only from the site's own browsing context

### DIFF
--- a/.chachalog/Qk3xRzPd.md
+++ b/.chachalog/Qk3xRzPd.md
@@ -1,0 +1,10 @@
+---
+# Allowed version bumps: patch, minor, major
+jahia-csrf-guard: patch
+---
+
+Restricted content changes to requests that the browser reports as coming from the site itself.
+
+Integrations that post to Jahia from another site, such as an identity provider or a notification service, must be listed in the `crossSiteWriteWhitelist` property of a module configuration to keep working — the SAML callback already is. The check can be turned off by setting `crossSiteWriteProtection.enabled` to `false` in the module's global configuration.
+
+URL pattern and whitelist matching now strips matrix parameters (`;name=value`) from the request path before matching, so a pattern or whitelist entry is compared against the path Jahia resolves. This also applies to the existing `urlPatterns` and `whitelist` used by token validation.

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   release-module:
     uses: Jahia/jahia-modules-action/.github/workflows/reusable-release-module.yml@v2
-    secrets: inherit 
+    secrets: inherit
     with:
-      primary_release_branch: "master"
+      # The release job checks out this branch and releases it, so it has to be the branch the
+      # release targets — "main" for a regular release, a maintenance branch such as 4_2_x for a
+      # patch release. Hardcoding it releases the wrong code under the requested version number.
+      primary_release_branch: ${{ github.event.release.target_commitish }}

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>jahia-csrf-guard</artifactId>
     <name>Jahia CSRF Guard</name>
-    <version>4.2.0</version>
+    <version>4.2.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (jahia-csrf-guard) to protect Jahia from CSRF attack.</description>
 
@@ -111,6 +111,18 @@
             <artifactId>spring-web</artifactId>
             <version>${spring.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <connection>scm:git:git@github.com:Jahia/jahia-csrf-guard.git</connection>
         <developerConnection>scm:git:git@github.com:Jahia/jahia-csrf-guard.git</developerConnection>
         <url>https://github.com/Jahia/jahia-csrf-guard</url>
-        <tag>4_2_0</tag>
+        <tag>4_2_x</tag>
     </scm>
 
     <properties>

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfig.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfig.java
@@ -36,10 +36,14 @@ public class JahiaCsrfGuardConfig {
 
     public static final String URL_PATTERNS = "urlPatterns";
     public static final String WHITELIST = "whitelist";
+    public static final String CROSS_SITE_WRITE_URL_PATTERNS = "crossSiteWriteUrlPatterns";
+    public static final String CROSS_SITE_WRITE_WHITELIST = "crossSiteWriteWhitelist";
 
     private String pid;
     private List<Pattern> urlPatterns;
-    private List<Pattern> whitelist;
+    private List<Pattern> whitelistPatterns;
+    private List<Pattern> crossSiteWriteUrlPatterns;
+    private List<Pattern> crossSiteWriteWhitelistPatterns;
 
     public JahiaCsrfGuardConfig() {
     }
@@ -56,15 +60,35 @@ public class JahiaCsrfGuardConfig {
         if (StringUtils.isNotEmpty(whitelist)) {
             config.setWhitelist(whitelist);
         }
+        String crossSiteWriteUrlPatterns = (String) properties.get(CROSS_SITE_WRITE_URL_PATTERNS);
+        if (StringUtils.isNotEmpty(crossSiteWriteUrlPatterns)) {
+            config.setCrossSiteWriteUrlPatterns(crossSiteWriteUrlPatterns);
+        }
+        String crossSiteWriteWhitelist = (String) properties.get(CROSS_SITE_WRITE_WHITELIST);
+        if (StringUtils.isNotEmpty(crossSiteWriteWhitelist)) {
+            config.setCrossSiteWriteWhitelist(crossSiteWriteWhitelist);
+        }
         return config;
     }
 
     public void setUrlPatterns(String urlPatterns) {
-        this.urlPatterns = Arrays.stream(urlPatterns.split(",")).map(String::trim).map(JahiaCsrfGuardConfig::createUrlPattern).collect(Collectors.toList());
+        this.urlPatterns = compile(urlPatterns);
     }
 
     public void setWhitelist(String whitelist) {
-        this.whitelist = Arrays.stream(whitelist.split(",")).map(String::trim).map(JahiaCsrfGuardConfig::createUrlPattern).collect(Collectors.toList());
+        this.whitelistPatterns = compile(whitelist);
+    }
+
+    public void setCrossSiteWriteUrlPatterns(String crossSiteWriteUrlPatterns) {
+        this.crossSiteWriteUrlPatterns = compile(crossSiteWriteUrlPatterns);
+    }
+
+    public void setCrossSiteWriteWhitelist(String crossSiteWriteWhitelist) {
+        this.crossSiteWriteWhitelistPatterns = compile(crossSiteWriteWhitelist);
+    }
+
+    private static List<Pattern> compile(String patterns) {
+        return Arrays.stream(patterns.split(",")).map(String::trim).map(JahiaCsrfGuardConfig::createUrlPattern).collect(Collectors.toList());
     }
 
     /**
@@ -89,12 +113,7 @@ public class JahiaCsrfGuardConfig {
      * @return true if CsrfGuardFilter should be applied
      */
     public boolean isFiltered(ServletRequest request) {
-        if (urlPatterns == null) {
-            return false;
-        }
-
-        String uri = ((HttpServletRequest) request).getRequestURI();
-        return urlPatterns.stream().anyMatch(pattern -> pattern.matcher(uri).matches());
+        return matches(urlPatterns, request);
     }
 
     /**
@@ -103,11 +122,53 @@ public class JahiaCsrfGuardConfig {
      * @return true if URL is whitelisted for CsrfGuardFilter, so it should not be applied
      */
     public boolean isWhiteListed(ServletRequest request) {
-        if (whitelist == null) {
+        return matches(whitelistPatterns, request);
+    }
+
+    /**
+     * @return true if this configuration sets the scope of the fetch metadata request policy
+     */
+    public boolean hasCrossSiteWriteUrlPatterns() {
+        return crossSiteWriteUrlPatterns != null;
+    }
+
+    /**
+     * Check url patterns configuration to see whether the fetch metadata request policy applies to the current request
+     * @param request client request object for servlet
+     * @return true if the policy should be applied
+     */
+    public boolean isCrossSiteWriteFiltered(ServletRequest request) {
+        return matches(crossSiteWriteUrlPatterns, request);
+    }
+
+    /**
+     * Check whitelist configuration to see whether the fetch metadata request policy is bypassed for the current request
+     * @param request client request object for servlet
+     * @return true if URL is whitelisted, so the policy should not be applied
+     */
+    public boolean isCrossSiteWriteWhiteListed(ServletRequest request) {
+        return matches(crossSiteWriteWhitelistPatterns, request);
+    }
+
+    private static boolean matches(List<Pattern> patterns, ServletRequest request) {
+        if (patterns == null) {
             return false;
         }
-        String uri = ((HttpServletRequest) request).getRequestURI();
-        return whitelist.stream().anyMatch(pattern -> pattern.matcher(uri).matches());
+        String uri = normalizePath(((HttpServletRequest) request).getRequestURI());
+        return patterns.stream().anyMatch(pattern -> pattern.matcher(uri).matches());
+    }
+
+    /**
+     * Strip the matrix parameters from every segment of a request URI, so a pattern is matched against the path Jahia
+     * resolves rather than the raw URI. Without this, a cross-site write to {@code /home.html;x=.saml} would end in
+     * {@code .saml}, match a {@code *.saml} whitelist and bypass the policy, while Jahia's Render dispatch drops the
+     * matrix parameter and still writes {@code /home.html}. The query string is not part of the URI, so it is untouched.
+     *
+     * @param uri a raw request URI, may be null
+     * @return the URI with each segment's {@code ;matrix=params} removed
+     */
+    public static String normalizePath(String uri) {
+        return uri == null ? "" : uri.replaceAll(";[^/]*", "");
     }
 
     @Override

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfigFactory.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfigFactory.java
@@ -23,8 +23,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Dictionary;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Dynamic configuration to mainly set url patterns to apply CsrfGuardFilter on a request and whitelisting urls, which should be bypassed.
@@ -34,7 +34,10 @@ public class JahiaCsrfGuardConfigFactory implements ManagedServiceFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JahiaCsrfGuardConfigFactory.class);
 
-    private final Map<String, JahiaCsrfGuardConfig> configs = new HashMap<>();
+    // A concurrent map so the live values() view handed to the filters stays safe to iterate on request threads while
+    // ConfigAdmin mutates it through updated()/deleted(): the reference to the factory is bound once and never re-bound
+    // on a configuration change, so the filters keep iterating that same view.
+    private final Map<String, JahiaCsrfGuardConfig> configs = new ConcurrentHashMap<>();
 
     public JahiaCsrfGuardConfigFactory() {
         LOGGER.debug("Creating Jahia CSRF Guard Config Factory");

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardGlobalConfig.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardGlobalConfig.java
@@ -49,7 +49,7 @@ public class JahiaCsrfGuardGlobalConfig {
     public static final String CROSS_SITE_WRITE_PROTECTION_ENABLED = "jahia.csrf-guard.crossSiteWriteProtection.enabled";
 
     private Map<String, String> config = new HashMap<>();
-    private boolean enabled = true;
+    private boolean serviceEnabled = true;
     private String servletAlias = "";
     private String servletPath = "";
     private boolean bypassForGuest = true;
@@ -87,11 +87,11 @@ public class JahiaCsrfGuardGlobalConfig {
     }
 
     public boolean isEnabled() {
-        return enabled;
+        return serviceEnabled;
     }
 
     public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
+        this.serviceEnabled = enabled;
     }
 
     public String getServletAlias() {
@@ -151,18 +151,18 @@ public class JahiaCsrfGuardGlobalConfig {
         if (o == null || getClass() != o.getClass())
             return false;
         JahiaCsrfGuardGlobalConfig that = (JahiaCsrfGuardGlobalConfig) o;
-        return enabled == that.enabled && bypassForGuest == that.bypassForGuest && Objects.equals(servletAlias, that.servletAlias)
+        return serviceEnabled == that.serviceEnabled && bypassForGuest == that.bypassForGuest && Objects.equals(servletAlias, that.servletAlias)
                 && Objects.equals(servletPath, that.servletPath) && Objects.equals(resolvedUrlPatterns, that.resolvedUrlPatterns)
                 && Objects.equals(multipartResolver, that.multipartResolver)
                 && crossSiteWriteProtectionEnabled == that.crossSiteWriteProtectionEnabled;
     }
 
     @Override public int hashCode() {
-        return Objects.hash(enabled, servletAlias, servletPath, bypassForGuest, resolvedUrlPatterns, multipartResolver, crossSiteWriteProtectionEnabled);
+        return Objects.hash(serviceEnabled, servletAlias, servletPath, bypassForGuest, resolvedUrlPatterns, multipartResolver, crossSiteWriteProtectionEnabled);
     }
 
     @Override public String toString() {
-        return "JahiaCsrfGuardGlobalConfig{" + "enabled=" + enabled + ", servletPath='" + servletPath + '\'' + ", bypassForGuest="
+        return "JahiaCsrfGuardGlobalConfig{" + "enabled=" + serviceEnabled + ", servletPath='" + servletPath + '\'' + ", bypassForGuest="
                 + bypassForGuest + ", resolvedUrlPatterns=" + resolvedUrlPatterns + ", crossSiteWriteProtectionEnabled=" + crossSiteWriteProtectionEnabled + '}';
     }
 }

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardGlobalConfig.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardGlobalConfig.java
@@ -46,6 +46,7 @@ public class JahiaCsrfGuardGlobalConfig {
     public static final String SERVLET_ALIAS = "jahia.csrf-guard.servletAlias";
     public static final String BYPASS_FOR_GUEST = "jahia.csrf-guard.bypassForGuest";
     public static final String RESOLVED_URL_PATTERNS = "jahia.csrf-guard.resolvedUrlPatterns";
+    public static final String CROSS_SITE_WRITE_PROTECTION_ENABLED = "jahia.csrf-guard.crossSiteWriteProtection.enabled";
 
     private Map<String, String> config = new HashMap<>();
     private boolean enabled = true;
@@ -54,6 +55,7 @@ public class JahiaCsrfGuardGlobalConfig {
     private boolean bypassForGuest = true;
     private List<String> resolvedUrlPatterns = new ArrayList<>();
     private MultipartResolver multipartResolver;
+    private boolean crossSiteWriteProtectionEnabled = true;
 
     @Activate
     @Modified
@@ -68,6 +70,7 @@ public class JahiaCsrfGuardGlobalConfig {
                 new ArrayList<>() :
                 List.of(config.get(RESOLVED_URL_PATTERNS).split(",")));
         this.setMultipartResolver(new CommonsMultipartResolver());
+        this.setCrossSiteWriteProtectionEnabled(config.getOrDefault(CROSS_SITE_WRITE_PROTECTION_ENABLED, "true").equalsIgnoreCase("true"));
         LOGGER.debug("Updated Jahia CSRF Guard Global configuration: {}", this);
     }
 
@@ -131,6 +134,17 @@ public class JahiaCsrfGuardGlobalConfig {
         this.multipartResolver = multipartResolver;
     }
 
+    /**
+     * @return true when write requests are accepted only from the site's own browsing context
+     */
+    public boolean isCrossSiteWriteProtectionEnabled() {
+        return crossSiteWriteProtectionEnabled;
+    }
+
+    public void setCrossSiteWriteProtectionEnabled(boolean crossSiteWriteProtectionEnabled) {
+        this.crossSiteWriteProtectionEnabled = crossSiteWriteProtectionEnabled;
+    }
+
     @Override public boolean equals(Object o) {
         if (this == o)
             return true;
@@ -139,15 +153,16 @@ public class JahiaCsrfGuardGlobalConfig {
         JahiaCsrfGuardGlobalConfig that = (JahiaCsrfGuardGlobalConfig) o;
         return enabled == that.enabled && bypassForGuest == that.bypassForGuest && Objects.equals(servletAlias, that.servletAlias)
                 && Objects.equals(servletPath, that.servletPath) && Objects.equals(resolvedUrlPatterns, that.resolvedUrlPatterns)
-                && Objects.equals(multipartResolver, that.multipartResolver);
+                && Objects.equals(multipartResolver, that.multipartResolver)
+                && crossSiteWriteProtectionEnabled == that.crossSiteWriteProtectionEnabled;
     }
 
     @Override public int hashCode() {
-        return Objects.hash(enabled, servletAlias, servletPath, bypassForGuest, resolvedUrlPatterns, multipartResolver);
+        return Objects.hash(enabled, servletAlias, servletPath, bypassForGuest, resolvedUrlPatterns, multipartResolver, crossSiteWriteProtectionEnabled);
     }
 
     @Override public String toString() {
         return "JahiaCsrfGuardGlobalConfig{" + "enabled=" + enabled + ", servletPath='" + servletPath + '\'' + ", bypassForGuest="
-                + bypassForGuest + ", resolvedUrlPatterns=" + resolvedUrlPatterns + '}';
+                + bypassForGuest + ", resolvedUrlPatterns=" + resolvedUrlPatterns + ", crossSiteWriteProtectionEnabled=" + crossSiteWriteProtectionEnabled + '}';
     }
 }

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
@@ -1,0 +1,202 @@
+package org.jahia.modules.jahiacsrfguard.filters;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jahia.bin.Render;
+import org.jahia.bin.filters.AbstractServletFilter;
+import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardConfig;
+import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardConfigFactory;
+import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardGlobalConfig;
+import org.osgi.service.component.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+/**
+ * Applies the fetch metadata request policy: a request that writes content is served only when the browser reports
+ * it as originating from the site's own browsing context, i.e. the <code>Sec-Fetch-Site</code> request header is
+ * absent or holds anything other than <code>cross-site</code>.
+ * <p>
+ * A request writes content when its HTTP method is a write method, or when its query string supplies a
+ * <code>jcrMethodToCall</code> method Jahia acts upon in place of the HTTP method. The query string is read on its
+ * own so that the policy never triggers request body parsing, which the request encoding depends on.
+ * <p>
+ * The policy covers every URL except the ones it exempts itself, and both are configurable through the
+ * {@code crossSiteWriteUrlPatterns} and {@code crossSiteWriteWhitelist} properties of any
+ * {@code org.jahia.modules.jahiacsrfguard-*} configuration; {@code jahia.csrf-guard.crossSiteWriteProtection.enabled} drives the
+ * policy as a whole.
+ */
+@Component(immediate = true, service = AbstractServletFilter.class)
+public class FetchMetadataFilter extends AbstractServletFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FetchMetadataFilter.class);
+
+    static final String SEC_FETCH_SITE_HEADER = "Sec-Fetch-Site";
+    static final String CROSS_SITE = "cross-site";
+
+    private static final Set<String> WRITE_METHODS = new HashSet<>(Arrays.asList("POST", "PUT", "DELETE", "PATCH"));
+
+    /** URLs reached from another site by design: an identity provider posts its assertion back to Jahia on *.saml */
+    private static final List<Pattern> BUILT_IN_WHITELIST = Collections.singletonList(JahiaCsrfGuardConfig.createUrlPattern("*.saml"));
+
+    // AtomicReference (a thread-safe type) rather than a volatile reference: configs is re-bound (DYNAMIC reference)
+    // while request threads read it, globalConfig is set once before activation. A volatile non-primitive field
+    // publishes only the reference, not the referenced state, which Sonar flags (java:S3077).
+    private final AtomicReference<JahiaCsrfGuardGlobalConfig> globalConfig = new AtomicReference<>();
+    private final AtomicReference<Collection<JahiaCsrfGuardConfig>> configs = new AtomicReference<>(new HashSet<>());
+
+    @Activate
+    public void activate() {
+        LOGGER.debug("Activating Jahia CSRF Guard Fetch Metadata Filter");
+        setFilterName("Jahia CSRF Guard Fetch Metadata Filter");
+        setMatchAllUrls(true);
+        setUrlPatterns(new String[] { "/*" });
+        // decide on the incoming request, before it is dispatched further and before the error page it may lead to
+        setDispatcherTypes(Set.of(DispatcherType.REQUEST.name()));
+        setOrder(-1.0f);
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+        // nothing to initialize, the policy is driven by configuration
+    }
+
+    @Override
+    public void destroy() {
+        // nothing to release
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        if (isRejected(httpRequest)) {
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn("Rejected request (ip:{}, method:{}, uri:{}, {}:{}, Origin:{})", httpRequest.getRemoteAddr(), httpRequest.getMethod(),
+                        httpRequest.getRequestURI(), SEC_FETCH_SITE_HEADER, httpRequest.getHeader(SEC_FETCH_SITE_HEADER), httpRequest.getHeader("Origin"));
+            }
+            ((HttpServletResponse) response).sendError(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
+        chain.doFilter(request, response);
+    }
+
+    boolean isRejected(HttpServletRequest request) {
+        JahiaCsrfGuardGlobalConfig currentGlobalConfig = globalConfig.get();
+        return currentGlobalConfig != null && currentGlobalConfig.isEnabled() && currentGlobalConfig.isCrossSiteWriteProtectionEnabled()
+                && isCrossSite(request.getHeader(SEC_FETCH_SITE_HEADER))
+                && isWriteRequest(request)
+                && isFiltered(request) && !isWhiteListed(request);
+    }
+
+    /**
+     * @param secFetchSite value of the {@code Sec-Fetch-Site} request header
+     * @return true when the browser reports a cross-site initiator
+     */
+    static boolean isCrossSite(String secFetchSite) {
+        return CROSS_SITE.equalsIgnoreCase(StringUtils.trimToEmpty(secFetchSite));
+    }
+
+    /**
+     * @param request client request object for servlet
+     * @return true when the request writes content, by its HTTP method or by the method its query string asks Jahia to call
+     */
+    static boolean isWriteRequest(HttpServletRequest request) {
+        return isWriteMethod(request.getMethod()) || queryStringAsksForWrite(request.getQueryString());
+    }
+
+    /**
+     * @param method a method name
+     * @return true when the method writes content
+     */
+    static boolean isWriteMethod(String method) {
+        return WRITE_METHODS.contains(StringUtils.upperCase(StringUtils.trimToEmpty(method)));
+    }
+
+    /**
+     * Read the {@code jcrMethodToCall} values held by a query string. Names and values are decoded the way the
+     * container decodes them, and every occurrence counts, so that a value reaching Jahia is a value seen here.
+     *
+     * @param queryString the raw query string, may be null
+     * @return true when one of the values is a write method
+     */
+    static boolean queryStringAsksForWrite(String queryString) {
+        // read the raw query string, never request.getParameter(): getParameter() merges query and body parameters, so
+        // on a POST it parses the request body — which this early filter (order -1.0, ahead of the multi-read wrapper)
+        // must not consume — and freezes the character encoding, making a later setCharacterEncoding() a no-op.
+        if (StringUtils.isEmpty(queryString)) {
+            return false;
+        }
+        for (String pair : StringUtils.split(queryString, '&')) {
+            String name = decode(StringUtils.substringBefore(pair, "="));
+            if (Render.METHOD_TO_CALL.equals(name) && isWriteMethod(decode(StringUtils.substringAfter(pair, "=")))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String decode(String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException | IllegalArgumentException e) {
+            LOGGER.debug("Reading query string value as supplied: {}", value, e);
+            return value;
+        }
+    }
+
+    /**
+     * Check all url pattern configurations to see whether the policy applies to the current request. The policy covers
+     * every URL as long as no configuration sets a scope, so that it holds on an installation whose configuration files
+     * predate it.
+     */
+    private boolean isFiltered(ServletRequest request) {
+        Collection<JahiaCsrfGuardConfig> currentConfigs = configs.get();
+        return currentConfigs.stream().noneMatch(JahiaCsrfGuardConfig::hasCrossSiteWriteUrlPatterns)
+                || currentConfigs.stream().anyMatch(config -> config.isCrossSiteWriteFiltered(request));
+    }
+
+    /**
+     * Check all whitelist configurations, and the URLs exempted by the module itself, to see whether the policy is
+     * bypassed for the current request
+     */
+    private boolean isWhiteListed(ServletRequest request) {
+        String uri = JahiaCsrfGuardConfig.normalizePath(((HttpServletRequest) request).getRequestURI());
+        return BUILT_IN_WHITELIST.stream().anyMatch(pattern -> pattern.matcher(uri).matches())
+                || configs.get().stream().anyMatch(config -> config.isCrossSiteWriteWhiteListed(request));
+    }
+
+    @Reference(service = JahiaCsrfGuardGlobalConfig.class, cardinality = ReferenceCardinality.MANDATORY, unbind = "-")
+    public void setGlobalConfig(JahiaCsrfGuardGlobalConfig globalConfig) {
+        this.globalConfig.set(globalConfig);
+    }
+
+    @Reference(service = JahiaCsrfGuardConfigFactory.class, policy = ReferencePolicy.DYNAMIC, bind = "setConfigs", unbind = "clearConfigs")
+    public void setConfigs(JahiaCsrfGuardConfigFactory configFactory) {
+        LOGGER.debug("Setting configurations from factory: {}", configFactory.getName());
+        this.configs.set(configFactory.getConfigs());
+    }
+
+    public void clearConfigs(JahiaCsrfGuardConfigFactory configFactory) {
+        LOGGER.debug("Clearing configurations from factory: {}", configFactory.getName());
+        this.configs.set(new HashSet<>());
+    }
+}

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard-default.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard-default.cfg
@@ -2,3 +2,9 @@
 
 urlPatterns = *.do, */\\\\*
 whitelist = *.myAction.do
+
+# fetch metadata request policy: the URLs it covers, and the URLs reached from another site by design.
+# These are the values the module applies on its own, restate them here only to narrow the scope or to
+# exempt a URL in addition to the SAML callback the module always exempts.
+# crossSiteWriteUrlPatterns = /*
+# crossSiteWriteWhitelist = *.saml

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard.global.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard.global.cfg
@@ -2,3 +2,4 @@ jahia.csrf-guard.enabled = true
 jahia.csrf-guard.servletAlias = /CsrfServlet
 jahia.csrf-guard.bypassForGuest = true
 jahia.csrf-guard.resolvedUrlPatterns = *.jsp,*.html,*.htm
+jahia.csrf-guard.crossSiteWriteProtection.enabled = true

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfigTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfigTest.java
@@ -1,0 +1,59 @@
+package org.jahia.modules.jahiacsrfguard;
+
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the matrix-parameter normalization that {@link JahiaCsrfGuardConfig#matches} now applies. Because the existing
+ * token filter's {@code isFiltered}/{@code isWhiteListed} route through the same helper, this normalization also shifts
+ * their matching — a matrix-param URI is matched on the path Jahia resolves, not on the raw request URI.
+ */
+public class JahiaCsrfGuardConfigTest {
+
+    @Test
+    public void normalizePathStripsMatrixParametersPerSegment() {
+        assertEquals("/home.html", JahiaCsrfGuardConfig.normalizePath("/home.html;x=.saml"));
+        assertEquals("/a/b/c", JahiaCsrfGuardConfig.normalizePath("/a;p=1/b;q=2/c"));
+        assertEquals("/home/", JahiaCsrfGuardConfig.normalizePath("/home/"));
+        assertEquals("/a/", JahiaCsrfGuardConfig.normalizePath("/a;jsessionid=xyz/"));
+        assertEquals("", JahiaCsrfGuardConfig.normalizePath(null));
+    }
+
+    @Test
+    public void urlPatternMatchingNormalizesMatrixParameters() {
+        JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.URL_PATTERNS, "*.do");
+        // a matrix parameter no longer hides the .do suffix the pattern selects
+        assertTrue(config.isFiltered(request("/home.logAction.do;jsessionid=abc")));
+        assertTrue(config.isFiltered(request("/home.logAction.do")));
+    }
+
+    @Test
+    public void whitelistMatchingCannotBeForgedByAMatrixParameter() {
+        JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.WHITELIST, "*.saml");
+        // a request Jahia resolves to /home.html must not borrow the *.saml exemption through a matrix parameter
+        assertFalse(config.isWhiteListed(request("/sites/site/home.html;x=.saml")));
+        assertTrue(config.isWhiteListed(request("/sites/site/home.callback.saml")));
+        assertTrue(config.isWhiteListed(request("/sites/site/home.callback.saml;jsessionid=abc")));
+    }
+
+    private static JahiaCsrfGuardConfig config(String property, String value) {
+        Dictionary<String, Object> properties = new Hashtable<>();
+        properties.put(property, value);
+        return JahiaCsrfGuardConfig.build("org.jahia.modules.jahiacsrfguard-test", properties);
+    }
+
+    private static HttpServletRequest request(String uri) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn(uri);
+        return request;
+    }
+}

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
@@ -1,0 +1,213 @@
+package org.jahia.modules.jahiacsrfguard.filters;
+
+import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardConfig;
+import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardConfigFactory;
+import org.jahia.modules.jahiacsrfguard.JahiaCsrfGuardGlobalConfig;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FetchMetadataFilterTest {
+
+    private static final String RENDER_URI = "/en/sites/mysite/home";
+
+    private FetchMetadataFilter filter;
+
+    @Before
+    public void setUp() {
+        filter = new FetchMetadataFilter();
+        filter.setGlobalConfig(globalConfig(Map.of()));
+        filter.setConfigs(configFactory("/*", "*.saml"));
+    }
+
+    // --- Sec-Fetch-Site reading -------------------------------------------------------------------------------------
+
+    @Test
+    public void crossSiteIsRecognized() {
+        assertTrue(FetchMetadataFilter.isCrossSite("cross-site"));
+        assertTrue(FetchMetadataFilter.isCrossSite("Cross-Site"));
+        assertTrue(FetchMetadataFilter.isCrossSite(" cross-site "));
+    }
+
+    @Test
+    public void otherSiteValuesAreNotCrossSite() {
+        assertFalse(FetchMetadataFilter.isCrossSite("same-origin"));
+        assertFalse(FetchMetadataFilter.isCrossSite("same-site"));
+        assertFalse(FetchMetadataFilter.isCrossSite("none"));
+        assertFalse(FetchMetadataFilter.isCrossSite(""));
+        assertFalse(FetchMetadataFilter.isCrossSite(null));
+    }
+
+    // --- write detection --------------------------------------------------------------------------------------------
+
+    @Test
+    public void writeMethodsAreRecognized() {
+        assertTrue(FetchMetadataFilter.isWriteMethod("POST"));
+        assertTrue(FetchMetadataFilter.isWriteMethod("PUT"));
+        assertTrue(FetchMetadataFilter.isWriteMethod("DELETE"));
+        assertTrue(FetchMetadataFilter.isWriteMethod("PATCH"));
+        assertTrue(FetchMetadataFilter.isWriteMethod("put"));
+        assertTrue(FetchMetadataFilter.isWriteMethod(" Put "));
+    }
+
+    @Test
+    public void readMethodsAreNotWriteMethods() {
+        assertFalse(FetchMetadataFilter.isWriteMethod("GET"));
+        assertFalse(FetchMetadataFilter.isWriteMethod("HEAD"));
+        assertFalse(FetchMetadataFilter.isWriteMethod("OPTIONS"));
+        assertFalse(FetchMetadataFilter.isWriteMethod(""));
+        assertFalse(FetchMetadataFilter.isWriteMethod(null));
+    }
+
+    @Test
+    public void queryStringMethodIsRead() {
+        assertTrue(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall=put"));
+        assertTrue(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall=PUT"));
+        assertTrue(FetchMetadataFilter.queryStringAsksForWrite("a=1&jcrMethodToCall=delete&b=2"));
+        assertTrue(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall=get&jcrMethodToCall=put"));
+    }
+
+    @Test
+    public void percentEncodedQueryStringMethodIsRead() {
+        assertTrue(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall=%70ut"));
+        assertTrue(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodTo%43all=put"));
+    }
+
+    @Test
+    public void queryStringWithoutWriteMethodIsRead() {
+        assertFalse(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall=get"));
+        assertFalse(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall="));
+        assertFalse(FetchMetadataFilter.queryStringAsksForWrite("otherParam=put"));
+        assertFalse(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCallSuffix=put"));
+        assertFalse(FetchMetadataFilter.queryStringAsksForWrite(""));
+        assertFalse(FetchMetadataFilter.queryStringAsksForWrite(null));
+    }
+
+    @Test
+    public void valuesThatDoNotDecodeAreReadAsSupplied() {
+        assertTrue(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall=put&jcrMethodToCall=%zz"));
+        assertFalse(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall=put%"));
+        assertFalse(FetchMetadataFilter.queryStringAsksForWrite("jcrMethodToCall=%zz"));
+    }
+
+    // --- the policy -------------------------------------------------------------------------------------------------
+
+    @Test
+    public void crossSitePostIsRejected() {
+        assertTrue(filter.isRejected(request("POST", RENDER_URI, null, "cross-site")));
+    }
+
+    @Test
+    public void crossSiteGetSupplyingAWriteMethodIsRejected() {
+        assertTrue(filter.isRejected(request("GET", RENDER_URI, "jcrMethodToCall=put&j:title=x", "cross-site")));
+    }
+
+    @Test
+    public void crossSiteActionPostIsRejected() {
+        assertTrue(filter.isRejected(request("POST", "/en/sites/site/home.logAction.do", null, "cross-site")));
+    }
+
+    @Test
+    public void crossSiteGetIsServed() {
+        assertFalse(filter.isRejected(request("GET", RENDER_URI, null, "cross-site")));
+    }
+
+    @Test
+    public void sameSiteWriteIsServed() {
+        assertFalse(filter.isRejected(request("POST", RENDER_URI, null, "same-site")));
+        assertFalse(filter.isRejected(request("POST", RENDER_URI, null, "same-origin")));
+        assertFalse(filter.isRejected(request("POST", RENDER_URI, null, "none")));
+        assertFalse(filter.isRejected(request("PUT", RENDER_URI, null, null)));
+    }
+
+    @Test
+    public void whitelistedUrlIsServed() {
+        assertFalse(filter.isRejected(request("POST", "/sites/site/home.callback.saml", null, "cross-site")));
+    }
+
+    @Test
+    public void matrixParameterCannotForgeAWhitelistedUrl() {
+        // /home.html ends in .saml only through a matrix parameter Jahia's Render dispatch drops before writing home.html
+        assertTrue(filter.isRejected(request("POST", "/sites/site/home.html;x=.saml", "jcrMethodToCall=put", "cross-site")));
+    }
+
+    @Test
+    public void matrixParameterDoesNotHideAGenuinelyWhitelistedUrl() {
+        assertFalse(filter.isRejected(request("POST", "/sites/site/home.callback.saml;jsessionid=abc", null, "cross-site")));
+    }
+
+    @Test
+    public void urlOutOfScopeIsServed() {
+        filter.setConfigs(configFactory("/cms/*", null));
+        assertTrue(filter.isRejected(request("POST", "/cms/render/live/fr/home", null, "cross-site")));
+        assertFalse(filter.isRejected(request("POST", RENDER_URI, null, "cross-site")));
+    }
+
+    @Test
+    public void policyOffServesEverything() {
+        filter.setGlobalConfig(globalConfig(Map.of(JahiaCsrfGuardGlobalConfig.CROSS_SITE_WRITE_PROTECTION_ENABLED, "false")));
+        assertFalse(filter.isRejected(request("POST", RENDER_URI, null, "cross-site")));
+    }
+
+    @Test
+    public void moduleOffServesEverything() {
+        filter.setGlobalConfig(globalConfig(Map.of(JahiaCsrfGuardGlobalConfig.ENABLED, "false")));
+        assertFalse(filter.isRejected(request("POST", RENDER_URI, null, "cross-site")));
+    }
+
+    @Test
+    public void withoutConfigurationThePolicyCoversEveryUrl() {
+        filter.clearConfigs(mock(JahiaCsrfGuardConfigFactory.class));
+        assertTrue(filter.isRejected(request("POST", RENDER_URI, null, "cross-site")));
+        assertTrue(filter.isRejected(request("POST", "/cms/render/live/fr/home", null, "cross-site")));
+    }
+
+    @Test
+    public void withoutConfigurationTheSamlCallbackIsServed() {
+        filter.clearConfigs(mock(JahiaCsrfGuardConfigFactory.class));
+        assertFalse(filter.isRejected(request("POST", "/sites/site/home.callback.saml", null, "cross-site")));
+    }
+
+    // --- fixtures ---------------------------------------------------------------------------------------------------
+
+    private static HttpServletRequest request(String method, String uri, String queryString, String secFetchSite) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn(method);
+        when(request.getRequestURI()).thenReturn(uri);
+        when(request.getQueryString()).thenReturn(queryString);
+        when(request.getHeader(FetchMetadataFilter.SEC_FETCH_SITE_HEADER)).thenReturn(secFetchSite);
+        return request;
+    }
+
+    private static JahiaCsrfGuardGlobalConfig globalConfig(Map<String, String> properties) {
+        JahiaCsrfGuardGlobalConfig config = new JahiaCsrfGuardGlobalConfig();
+        config.modified(properties);
+        return config;
+    }
+
+    private static JahiaCsrfGuardConfigFactory configFactory(String urlPatterns, String whitelist) {
+        Dictionary<String, Object> properties = new Hashtable<>();
+        if (urlPatterns != null) {
+            properties.put(JahiaCsrfGuardConfig.CROSS_SITE_WRITE_URL_PATTERNS, urlPatterns);
+        }
+        if (whitelist != null) {
+            properties.put(JahiaCsrfGuardConfig.CROSS_SITE_WRITE_WHITELIST, whitelist);
+        }
+        JahiaCsrfGuardConfigFactory factory = new JahiaCsrfGuardConfigFactory();
+        try {
+            factory.updated("org.jahia.modules.jahiacsrfguard-test", properties);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        return factory;
+    }
+}

--- a/tests/cypress/e2e/fetchMetadata.cy.ts
+++ b/tests/cypress/e2e/fetchMetadata.cy.ts
@@ -1,0 +1,142 @@
+import {addNode, createSite, deleteSite, publishAndWaitJobEnding} from '@jahia/cypress';
+import {updateCsrfGuardCrossSiteWriteWhiteList} from '../utils/utils';
+
+describe('Fetch metadata request policy tests', () => {
+    const targetSiteKey = 'csrfGuardSite';
+    const actionUrl = '/en/sites/' + targetSiteKey + '/home.logAction.do';
+    const pageUrl = '/en/sites/' + targetSiteKey + '/home.html';
+
+    before('Create target test site', () => {
+        cy.log('Create site ' + targetSiteKey + ' for csrf tests');
+        createSite(targetSiteKey, {locale: 'en', templateSet: 'jahia-csrf-guard-test-module', serverName: 'localhost'});
+        addNode({
+            parentPathOrId: `/sites/${targetSiteKey}/home`,
+            primaryNodeType: 'jnt:contentList',
+            name: 'pagecontent'
+        }).then(() => {
+            addNode({
+                parentPathOrId: `/sites/${targetSiteKey}/home/pagecontent`,
+                primaryNodeType: 'csrf:testContent',
+                name: 'test-content',
+                mixins: ['jmix:renderable']
+            }).then(() => {
+                publishAndWaitJobEnding('/sites/' + targetSiteKey + '/home');
+            });
+        });
+    });
+
+    beforeEach(() => {
+        cy.login();
+    });
+
+    afterEach(() => {
+        cy.logout();
+    });
+
+    /**
+     * Repeat the request until it answers the expected status: a configuration change reaches the module through its
+     * configuration file, which is read at its own pace.
+     */
+    const crossSiteWriteEventuallyAnswers = (expectedStatus: number, remainingAttempts = 25) => {
+        cy.request({
+            method: 'POST',
+            url: actionUrl,
+            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'cross-site'},
+            failOnStatusCode: false
+        }).then(response => {
+            if (response.status === expectedStatus || remainingAttempts === 0) {
+                expect(response.status).to.equal(expectedStatus);
+            } else {
+                // eslint-disable-next-line cypress/no-unnecessary-waiting
+                cy.wait(2000);
+                crossSiteWriteEventuallyAnswers(expectedStatus, remainingAttempts - 1);
+            }
+        });
+    };
+
+    it('should serve a write request reported as same-origin', () => {
+        cy.request({
+            method: 'POST',
+            url: actionUrl,
+            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'same-origin'},
+            failOnStatusCode: true
+        }).its('status').should('equal', 200);
+    });
+
+    it('should serve a write request when the header is absent', () => {
+        cy.request({
+            method: 'POST',
+            url: actionUrl,
+            headers: {Origin: Cypress.config().baseUrl},
+            failOnStatusCode: true
+        }).its('status').should('equal', 200);
+    });
+
+    it('should reject a write request reported as cross-site', () => {
+        cy.request({
+            method: 'POST',
+            url: actionUrl,
+            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'cross-site'},
+            failOnStatusCode: false
+        }).its('status').should('equal', 403);
+    });
+
+    it('should reject a cross-site request asking for a write method', () => {
+        cy.request({
+            method: 'GET',
+            url: pageUrl + '?jcrMethodToCall=put',
+            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'cross-site'},
+            failOnStatusCode: false
+        }).its('status').should('equal', 403);
+    });
+
+    // The policy keys on the request shape, not on what the request writes: a content-creation request
+    // through the render pipeline is served or refused on the same terms as any other write, whatever
+    // node type it carries.
+    const createChildUrl = '/cms/render/default/en/sites/' + targetSiteKey + '/home/pagecontent';
+
+    it('should serve a content-creation request reported as same-origin', () => {
+        cy.request({
+            method: 'POST',
+            url: createChildUrl,
+            form: true,
+            body: {jcrNodeType: 'jnt:contentList', nodeName: 'sameOriginChild'},
+            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'same-origin'},
+            followRedirect: false,
+            failOnStatusCode: false
+        }).its('status').should('be.oneOf', [200, 201, 303]);
+    });
+
+    it('should reject a cross-site content-creation request whatever node type it carries', () => {
+        cy.request({
+            method: 'POST',
+            url: createChildUrl,
+            form: true,
+            body: {jcrNodeType: 'jnt:contentList', nodeName: 'crossSiteChild'},
+            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'cross-site'},
+            followRedirect: false,
+            failOnStatusCode: false
+        }).its('status').should('equal', 403);
+    });
+
+    it('should serve a cross-site read request', () => {
+        cy.request({
+            method: 'GET',
+            url: pageUrl,
+            headers: {Origin: Cypress.config().baseUrl, 'Sec-Fetch-Site': 'cross-site'},
+            failOnStatusCode: true
+        }).its('status').should('equal', 200);
+    });
+
+    it('should exempt a whitelisted url and cover it again once removed', () => {
+        updateCsrfGuardCrossSiteWriteWhiteList('*.logAction.do');
+        crossSiteWriteEventuallyAnswers(200);
+        updateCsrfGuardCrossSiteWriteWhiteList('*.notAnAction.do');
+        crossSiteWriteEventuallyAnswers(403);
+    });
+
+    after('Clean', () => {
+        updateCsrfGuardCrossSiteWriteWhiteList('*.notAnAction.do');
+        deleteSite(targetSiteKey);
+    });
+});

--- a/tests/cypress/utils/utils.ts
+++ b/tests/cypress/utils/utils.ts
@@ -22,12 +22,32 @@ export const updateCsrfGuardWhiteListConfig = (whitelist?: string) => {
     }
 };
 
+export const updateCsrfGuardCrossSiteWriteWhiteList = (whitelist: string) => {
+    const conf = {
+        editConfiguration: 'org.jahia.modules.jahiacsrfguard-dummy',
+        configIdentifier: 'global',
+        properties: {
+            crossSiteWriteWhitelist: whitelist
+        }
+    };
+
+    cy.runProvisioningScript({fileContent: JSON.stringify([conf]), type: 'application/json'}, null);
+    if (Cypress.env('JAHIA_CLUSTER_ENABLED')) {
+        // Wait to allow to synchronize in cluster
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(20000);
+    } else {
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(10000);
+    }
+};
+
 export const updateCsrfGuardBypassGuest = (bypass: boolean) => {
     const conf = {
         editConfiguration: 'org.jahia.modules.jahiacsrfguard.global',
         configIdentifier: 'global',
         properties: {
-            'jahia.csrf-guard.bypassForGuest': bypass
+            'jahia.csrf-guard.bypassForGuest': String(bypass)
         }
     };
 

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -30,7 +30,7 @@
     <groupId>org.jahia.test</groupId>
     <artifactId>jahia-csrf-guard-test-module</artifactId>
     <name>Jahia CSRF Guard Test Module</name>
-    <version>4.2.0</version>
+    <version>4.2.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (jahia-csrf-guard-test-module) for running on a Jahia server.</description>
 
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>jahia-csrf-guard</artifactId>
-            <version>4.2.0-SNAPSHOT</version>
+            <version>4.2.1-SNAPSHOT</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
Backport of [jahia-csrf-guard#176](https://github.com/Jahia/jahia-csrf-guard/pull/176) to the new `4_2_x` maintenance branch, so the change can ship as **4.2.1** without waiting on a 4.3.0 release.

`4_2_x` was cut from the `4_2_0` tag (`6ed9984`). This PR also moves the branch to `4.2.1-SNAPSHOT`.

### Not a clean cherry-pick

`main` has moved since 4.2.0, so four things needed adapting:

| file | why it differed | resolution |
|---|---|---|
| `JahiaCsrfGuardGlobalConfig` | 4.2.0 still uses Spring's `multipartResolver`, dropped on main by [#168](https://github.com/Jahia/jahia-csrf-guard/pull/168) | hand-merged — the branch keeps it, and only gains the `crossSiteWriteProtection` key |
| `JahiaCsrfGuardGlobalConfig` | 4.2.0 names the field `enabled`, next to the constant `ENABLED`; main renamed it `serviceEnabled` in [#146](https://github.com/Jahia/jahia-csrf-guard/pull/146) | same rename applied here (`java:S1845`). Public API unchanged — `isEnabled()` / `setEnabled()` keep their names |
| `pom.xml` | `junit` / `mockito-core` reached main with #168, so the unit tests do not compile without them | added as `test` scope; `spring-web` stays |
| `docs/README.md` | the `docs/` tree was created after 4.2.0 by [#138](https://github.com/Jahia/jahia-csrf-guard/pull/138) | left out — the Academy publishes from `main` |

`JahiaCsrfGuardConfig` was taken from #176 verbatim: on main it is 4.2.0's file plus a private-field rename plus this change, so nothing else rides along.

The changelog fragment is `patch` here rather than `minor`, matching a 4.2.1 release.

### The release-workflow commit is a prerequisite, not housekeeping

`on-release.yml` on this branch still said `primary_release_branch: "master"` — a branch renamed away by [#161](https://github.com/Jahia/jahia-csrf-guard/pull/161). That input is not metadata: `jahia-modules-action/release` runs `git pull origin <it>` then `git checkout <it>` and releases **that** branch. Left as-is, a 4.2.1 pre-release would fail on the missing branch; and `main`'s copy, which says `"main"`, would release main's code under the 4.2.1 number. Both copies now derive it from `github.event.release.target_commitish` — see [#178](https://github.com/Jahia/jahia-csrf-guard/pull/178) for the `main` side and the reasoning.

### Verified locally

- `mvn test` — 24 unit tests pass (21 `FetchMetadataFilterTest`, 3 `JahiaCsrfGuardConfigTest`)
- `mvn package` — the bundle builds as `jahia-csrf-guard-4.2.1-SNAPSHOT.jar`
- analysed against a local SonarQube to confirm the `S1845` rename clears it and introduces nothing new

The pom still carries the 4.2.0 signature; CI's `update-signature` regenerates it for the new version.

### Note on this branch's CI

`on-merge.yml`, the nightlies and the Sonar schedule are all wired to `main` only, so `4_2_x` gets PR checks (`on-code-change.yml` fires on any base) but nothing after merge. Worth wiring separately if this branch is going to live.

Part of #179.