### PR TITLE
ci: release from the branch the release targets

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -11,4 +11,7 @@ jobs:
     uses: Jahia/jahia-modules-action/.github/workflows/reusable-release-module.yml@v2
     secrets: inherit 
     with:
-      primary_release_branch: "main"
+      # The release job checks out this branch and releases it, so it has to be the branch the
+      # release targets — "main" for a regular release, a maintenance branch such as 4_2_x for a
+      # patch release. Hardcoding it releases the wrong code under the requested version number.
+      primary_release_branch: ${{ github.event.release.target_commitish }}


### PR DESCRIPTION
`on-release.yml` hardcodes `primary_release_branch: "main"`, but the release action does not treat that as "the repo's main branch" — it literally moves to it:

```
git pull origin ${{ inputs.primary_release_branch }}
git checkout ${{ inputs.primary_release_branch }}
```

So the branch named there is the branch that gets released. Creating a pre-release against any other branch releases `main`'s code under the requested version number, and pushes the release/next-development commits onto `main`.

That matters now: `4_2_x` was just cut (from the `4_2_0` tag) to carry a 4.2.1 patch — see [jahia-csrf-guard#177](https://github.com/Jahia/jahia-csrf-guard/pull/177). Deriving the branch from `github.event.release.target_commitish` makes the job release whatever branch the release was created against, and is a no-op for releases targeting `main`.

The version arithmetic in the action already supports this: a `primary_release_branch` that is not `main`/`master`/`N_x` takes the patch-bump path, so releasing `4_2_1` from `4_2_x` correctly leaves the branch on `4.2.2-SNAPSHOT`.

The same one-line change is in #177 for the `4_2_x` copy, which still pointed at `master` — a branch that no longer exists. Both are changed because which copy of the workflow GitHub uses for a `release` event depends on the ref the event carries, and getting it wrong is not a failure worth risking on an irreversible step.