### PR TITLE
fix: publish snapshots from this maintenance branch

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: jahia/jahia-modules-action/sonar-analysis@v2
         with:
-          primary_release_branch: master
+          primary_release_branch: 4_2_x
           github_pr_id: ${{github.event.number}}
           sonar_url: ${{ secrets.SONAR_URL }}
           sonar_token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -1,12 +1,14 @@
 # This workflow is triggered every time a change is pushed to any branches
 # Github actions command reference: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
-name: On merge to master
+name: On merge to a release branch
 
 # The workflow could also be triggered on PRs
 on:
   push:
     branches:
+      - 'main'
       - 'master'
+      - '[0-9]*_x'
     tags-ignore:
       - '**'
 
@@ -105,7 +107,7 @@ jobs:
   publish:
     name: Publish module
     needs: build
-    if: github.ref == 'refs/heads/master'
+    if: github.ref_name == 'main' || github.ref_name == 'master' || endsWith(github.ref_name, '_x')
     runs-on: ubuntu-latest
     env:
       NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -1,14 +1,12 @@
 # This workflow is triggered every time a change is pushed to any branches
 # Github actions command reference: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
-name: On merge to a release branch
+name: On merge to 4_2_x
 
 # The workflow could also be triggered on PRs
 on:
   push:
     branches:
-      - 'main'
-      - 'master'
-      - '[0-9]*_x'
+      - '4_2_x'
     tags-ignore:
       - '**'
 
@@ -107,7 +105,7 @@ jobs:
   publish:
     name: Publish module
     needs: build
-    if: github.ref_name == 'main' || github.ref_name == 'master' || endsWith(github.ref_name, '_x')
+    if: github.ref == 'refs/heads/4_2_x'
     runs-on: ubuntu-latest
     env:
       NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -11,7 +11,4 @@ jobs:
     uses: Jahia/jahia-modules-action/.github/workflows/reusable-release-module.yml@v2
     secrets: inherit
     with:
-      # The release job checks out this branch and releases it, so it has to be the branch the
-      # release targets — "main" for a regular release, a maintenance branch such as 4_2_x for a
-      # patch release. Hardcoding it releases the wrong code under the requested version number.
-      primary_release_branch: ${{ github.event.release.target_commitish }}
+      primary_release_branch: 4_2_x

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -30,7 +30,7 @@
     <groupId>org.jahia.test</groupId>
     <artifactId>jahia-csrf-guard-test-module</artifactId>
     <name>Jahia CSRF Guard Test Module</name>
-    <version>4.2.1</version>
+    <version>4.2.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (jahia-csrf-guard-test-module) for running on a Jahia server.</description>
 


### PR DESCRIPTION
The 4.2.1 release job ([31104806048](https://github.com/Jahia/jahia-csrf-guard/actions/runs/31104806048)) failed. This unblocks the retry.

## What failed

The release action, when a repo has an **mvn tests module**, does this before anything else is built:

```bash
cd tests/jahia-module/
mvn versions:set -DnewVersion=4.2.1
git commit && git push
mvn deploy          # ← failed here
```

The tests module is its own reactor, so it resolves `org.jahia.modules:jahia-csrf-guard:4.2.1-SNAPSHOT`
from a repository, not from a build. That snapshot does not exist:

```
Could not collect dependencies for org.jahia.test:jahia-csrf-guard-test-module:bundle:4.2.1
Failed to read artifact descriptor for org.jahia.modules:jahia-csrf-guard:jar:4.2.1-SNAPSHOT
  → org.jahia.modules:jahia-csrf-guard:pom:4.2.1-SNAPSHOT (absent)
```

`4.3.0-SNAPSHOT` is in Nexus, `4.2.1-SNAPSHOT` is a 404.

## Why the snapshot is missing here and nowhere else

`on-merge.yml` on this branch still reads `push: branches: ['master']` and gates `publish` on
`refs/heads/master`. `4_2_x` was cut from the `4_2_0` tag, which predates the master → main rename,
so **nothing has ever run on a push to this branch** — including the `publish` job that deploys the
snapshot. Same root as the hardcoded `primary_release_branch` fixed in
[#178](https://github.com/Jahia/jahia-csrf-guard/pull/178): the branch carries a pre-rename copy of the CI.

This does not bite other maintenance branches, because none of them exercises the path:

| branch | mvn tests module | `<version>-SNAPSHOT` in Nexus |
|---|---|---|
| `sitemap` `4_0_x` | no | 404 |
| `app-shell` `2_7_x` | no | 200 |
| `jexperience` `1_11_x` | no | 404 |
| `augmented-search` `1_5_x` | no | 404 |
| `jahia-csrf-guard` `main` | **yes** | 200 — published by `on-merge` |
| `jahia-csrf-guard` `4_2_x` | **yes** | **404** |

Three of those four released from a maintenance branch with no snapshot in Nexus at all — they never
enter the `tests_module_type: mvn` branch of the release action, so they never need one.

## The change

Exactly what `main`'s `on-merge.yml` says, with `main` → `4_2_x` — no new syntax, nothing that
diverges from the other repos:

```diff
-name: On merge to master          +name: On merge to 4_2_x
-      - 'master'                  +      - '4_2_x'
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/4_2_x'
```

Second commit: the failed job had already pushed `ce993b6` straight to `4_2_x`, setting the tests
module to `4.2.1` — a release version depending on a snapshot. Restored to `4.2.1-SNAPSHOT`, which is
required for the retry: the release step re-runs `versions:set` then `git commit`, and under `bash -e`
a no-op commit aborts the job.

## Possibly an upstream gap rather than a repo one

The release action deploys the tests module **before** the module itself is built or installed, so on
any repo with an mvn tests module a release can only succeed if a matching `-SNAPSHOT` was already
published by an earlier workflow. `reusable-release-module.yml` has no build step ahead of it. If the
intent is that the release is self-contained, the fix belongs in `jahia-modules-action` (build/install
the module before deploying the tests module) and this PR is just the local unblock — happy to raise it
there instead.

Release ticket: [jahia-csrf-guard#179](https://github.com/Jahia/jahia-csrf-guard/issues/179)
