### PR TITLE
fix: match url patterns against the resolved request path

### DIFF
--- a/.chachalog/oCkwFuqg.md
+++ b/.chachalog/oCkwFuqg.md
@@ -3,3 +3,5 @@ jahia-csrf-guard: patch
 ---
 
 Matched URL patterns and whitelists against the resolved path, so an entry covers every spelling of the URL it names.
+
+Narrowed the exemption the module applies on its own to the SAML callback URL, `*callback.saml`, which is the SAML endpoint content changes arrive on. A site whose identity provider returns its response to another URL must list that URL in the `crossSiteWriteWhitelist` property of a module configuration — the setting to check is **Incoming Target Url**, whose default is `/home.callback.saml`.

--- a/.chachalog/oCkwFuqg.md
+++ b/.chachalog/oCkwFuqg.md
@@ -1,0 +1,5 @@
+---
+jahia-csrf-guard: patch
+---
+
+Matched URL patterns and whitelists against the resolved path, so an entry covers every spelling of the URL it names.

--- a/.chachalog/oCkwFuqg.md
+++ b/.chachalog/oCkwFuqg.md
@@ -3,5 +3,3 @@ jahia-csrf-guard: patch
 ---
 
 Matched URL patterns and whitelists against the resolved path, so an entry covers every spelling of the URL it names.
-
-Narrowed the exemption the module applies on its own to the SAML callback URL, `*callback.saml`, which is the SAML endpoint content changes arrive on. A site whose identity provider returns its response to another URL must list that URL in the `crossSiteWriteWhitelist` property of a module configuration — the setting to check is **Incoming Target Url**, whose default is `/home.callback.saml`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,8 @@ In such cases you would create a configuration in your module and whitelist the 
 whitelist = *.action1.do,*.action2.do
 ```
 
+A pattern is matched against the path the container reads from the request, so the URL forms Jahia serves as one action are covered as one: `*.action1.do` covers `/home.action1.do` and `/home.action1.do/` alike.
+
 You can find an example of such a configuration in the [saml-authentication-valve codebase](https://github.com/Jahia/saml-authentication-valve/blob/dd3b68c1bc7fba48de8eca4444861ac516ec5bc2/src/main/resources/META-INF/configurations/org.jahia.modules.jahiacsrfguard-saml.cfg).
 
 #### Referer check does not match the protocol
@@ -135,7 +137,7 @@ The policy covers all URLs; the `crossSiteWriteUrlPatterns` property narrows it 
 crossSiteWriteUrlPatterns = /cms/*, /en/sites/mysite/*
 ```
 
-> **Write these patterns against the URLs browsers request, not the ones Jahia resolves them to.** The filter runs on the incoming request (`REQUEST` dispatch) and matches its original URI. A content write to a site URL such as `POST /en/sites/mysite/home/foo` is served through an internal forward to `/cms/render/…`, which this filter never sees — so a scope of `/cms/*` on its own would match only the forwarded path and leave the original request uncovered. List the public entry-point spellings your writes actually use, or keep the default (all URLs), which is the safe choice.
+> **Write these patterns against the URLs browsers request, not the ones Jahia resolves them to.** The filter runs on the incoming request (`REQUEST` dispatch) and matches the path the container reads from its original URI — percent-decoded, without the context path, its matrix parameters and any trailing slash. A content write to a site URL such as `POST /en/sites/mysite/home/foo` is served through an internal forward to `/cms/render/…`, which this filter never sees — so a scope of `/cms/*` on its own would match only the forwarded path and leave the original request uncovered. List the public entry-point spellings your writes actually use, or keep the default (all URLs), which is the safe choice.
 
 Both properties accept the same comma-separated URL patterns as `urlPatterns` and `whitelist`, and apply across all sites of the platform.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -137,7 +137,7 @@ The policy covers all URLs; the `crossSiteWriteUrlPatterns` property narrows it 
 crossSiteWriteUrlPatterns = /cms/*, /en/sites/mysite/*
 ```
 
-> **Write these patterns against the URLs browsers request, not the ones Jahia resolves them to.** The filter runs on the incoming request (`REQUEST` dispatch) and matches the path the container reads from its original URI — percent-decoded, without the context path, its matrix parameters and any trailing slash. A content write to a site URL such as `POST /en/sites/mysite/home/foo` is served through an internal forward to `/cms/render/…`, which this filter never sees — so a scope of `/cms/*` on its own would match only the forwarded path and leave the original request uncovered. List the public entry-point spellings your writes actually use, or keep the default (all URLs), which is the safe choice.
+> **Write these patterns against the URLs browsers request, not the ones Jahia resolves them to.** The filter runs on the incoming request (`REQUEST` dispatch) and matches the path the container reads from its original URI — percent-decoded, context path included, without its matrix parameters and without a trailing slash. A content write to a site URL such as `POST /en/sites/mysite/home/foo` is served through an internal forward to `/cms/render/…`, which this filter never sees — so a scope of `/cms/*` on its own would match only the forwarded path and leave the original request uncovered. List the public entry-point spellings your writes actually use, or keep the default (all URLs), which is the safe choice.
 
 Both properties accept the same comma-separated URL patterns as `urlPatterns` and `whitelist`, and apply across all sites of the platform.
 

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfig.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfig.java
@@ -165,9 +165,12 @@ public class JahiaCsrfGuardConfig {
      * one URL to select, and the same holds for the other spellings the container folds away.
      * <p>
      * The servlet path and path info are what the container mapped: percent-decoded, with {@code /./} and repeated
-     * slashes collapsed and {@code /../} resolved. Matrix parameters and trailing slashes are dropped on top of that.
-     * The composed path starts below the context path, which is where a configured pattern starts too. A request the
-     * container mapped to no servlet is matched on its raw URI.
+     * slashes collapsed, {@code /../} resolved and path parameters parsed out. The context path is put back in front of
+     * them, so a pattern keeps being written against the same URL it always was, and trailing slashes are dropped.
+     * <p>
+     * The matrix-parameter strip belongs to the raw URI, and applies only where the raw URI is what gets matched. On the
+     * mapped path a {@code ;} is content the container decoded from a {@code %3B}, part of a segment's name — dropping
+     * from it would cut the path short and take the suffix a pattern selects with it.
      * <p>
      * This is the path of the request being filtered. An internal forward, such as the one that serves a site URL
      * through {@code /cms/render/…}, is a separate dispatch this filter is not registered for and never reads.
@@ -176,11 +179,12 @@ public class JahiaCsrfGuardConfig {
      * @return the path the container resolved, never null
      */
     public static String resolvedPath(HttpServletRequest request) {
-        String path = StringUtils.defaultString(request.getServletPath()) + StringUtils.defaultString(request.getPathInfo());
-        if (StringUtils.isEmpty(path)) {
-            path = request.getRequestURI();
+        String mapped = StringUtils.defaultString(request.getServletPath()) + StringUtils.defaultString(request.getPathInfo());
+        if (StringUtils.isEmpty(mapped)) {
+            // nothing mapped to read: match the raw URI, where a `;` still delimits path parameters
+            return stripTrailingSlashes(normalizePath(request.getRequestURI()));
         }
-        return stripTrailingSlashes(normalizePath(path));
+        return stripTrailingSlashes(StringUtils.defaultString(request.getContextPath()) + mapped);
     }
 
     /**
@@ -196,7 +200,8 @@ public class JahiaCsrfGuardConfig {
     }
 
     /**
-     * Strip the matrix parameters from every segment of a request URI, one of the steps {@link #resolvedPath} applies.
+     * Strip the matrix parameters from every segment of a raw request URI, the step {@link #resolvedPath} applies when a
+     * raw URI is what it has to match.
      * Without this, a cross-site write to {@code /home.html;x=.saml} would end in {@code .saml}, match a {@code *.saml}
      * whitelist and bypass the policy, while Jahia's Render dispatch drops the matrix parameter and still writes
      * {@code /home.html}. The query string is not part of the URI, so it is untouched.

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfig.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfig.java
@@ -155,7 +155,11 @@ public class JahiaCsrfGuardConfig {
             return false;
         }
         String path = resolvedPath((HttpServletRequest) request);
-        return patterns.stream().anyMatch(pattern -> pattern.matcher(path).matches());
+        // A pattern is tested against the path and against the path as a directory, because a prefix pattern names its
+        // own root: `/cms/*` compiles to `/cms/.*`, whose shortest match is `/cms/`. Testing both spellings lets such a
+        // pattern select the path it names, whether or not the request spelled the slash.
+        String asDirectory = path.endsWith("/") ? path : path + "/";
+        return patterns.stream().anyMatch(pattern -> pattern.matcher(path).matches() || pattern.matcher(asDirectory).matches());
     }
 
     /**

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfig.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfig.java
@@ -154,15 +154,52 @@ public class JahiaCsrfGuardConfig {
         if (patterns == null) {
             return false;
         }
-        String uri = normalizePath(((HttpServletRequest) request).getRequestURI());
-        return patterns.stream().anyMatch(pattern -> pattern.matcher(uri).matches());
+        String path = resolvedPath((HttpServletRequest) request);
+        return patterns.stream().anyMatch(pattern -> pattern.matcher(path).matches());
     }
 
     /**
-     * Strip the matrix parameters from every segment of a request URI, so a pattern is matched against the path Jahia
-     * resolves rather than the raw URI. Without this, a cross-site write to {@code /home.html;x=.saml} would end in
-     * {@code .saml}, match a {@code *.saml} whitelist and bypass the policy, while Jahia's Render dispatch drops the
-     * matrix parameter and still writes {@code /home.html}. The query string is not part of the URI, so it is untouched.
+     * The path a pattern is compared against: the one the container resolved for this request, so that the spellings
+     * Jahia serves as a single resource are matched as a single resource. Jahia's URLResolver drops a trailing slash
+     * before the render pipeline reads a path, which is what makes {@code /home.action.do/} and {@code /home.action.do}
+     * one URL to select, and the same holds for the other spellings the container folds away.
+     * <p>
+     * The servlet path and path info are what the container mapped: percent-decoded, with {@code /./} and repeated
+     * slashes collapsed and {@code /../} resolved. Matrix parameters and trailing slashes are dropped on top of that.
+     * The composed path starts below the context path, which is where a configured pattern starts too. A request the
+     * container mapped to no servlet is matched on its raw URI.
+     * <p>
+     * This is the path of the request being filtered. An internal forward, such as the one that serves a site URL
+     * through {@code /cms/render/…}, is a separate dispatch this filter is not registered for and never reads.
+     *
+     * @param request client request object for servlet
+     * @return the path the container resolved, never null
+     */
+    public static String resolvedPath(HttpServletRequest request) {
+        String path = StringUtils.defaultString(request.getServletPath()) + StringUtils.defaultString(request.getPathInfo());
+        if (StringUtils.isEmpty(path)) {
+            path = request.getRequestURI();
+        }
+        return stripTrailingSlashes(normalizePath(path));
+    }
+
+    /**
+     * @param path a request path
+     * @return the path without the trailing slashes URLResolver drops, a bare {@code /} kept as is
+     */
+    static String stripTrailingSlashes(String path) {
+        int end = path.length();
+        while (end > 1 && path.charAt(end - 1) == '/') {
+            end--;
+        }
+        return path.substring(0, end);
+    }
+
+    /**
+     * Strip the matrix parameters from every segment of a request URI, one of the steps {@link #resolvedPath} applies.
+     * Without this, a cross-site write to {@code /home.html;x=.saml} would end in {@code .saml}, match a {@code *.saml}
+     * whitelist and bypass the policy, while Jahia's Render dispatch drops the matrix parameter and still writes
+     * {@code /home.html}. The query string is not part of the URI, so it is untouched.
      *
      * @param uri a raw request URI, may be null
      * @return the URI with each segment's {@code ;matrix=params} removed

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
@@ -55,12 +55,8 @@ public class FetchMetadataFilter extends AbstractServletFilter {
 
     private static final Set<String> WRITE_METHODS = new HashSet<>(Arrays.asList("POST", "PUT", "DELETE", "PATCH"));
 
-    /**
-     * URLs reached from another site by design: an identity provider posts its assertion back to Jahia on the callback
-     * URL its SAML support serves, and that URL is the one endpoint of that support a write arrives on. This mirrors the
-     * condition the SAML filter dispatches on, so the exemption covers the endpoint that needs it and no other URL.
-     */
-    private static final List<Pattern> BUILT_IN_WHITELIST = Collections.singletonList(JahiaCsrfGuardConfig.createUrlPattern("*callback.saml"));
+    /** URLs reached from another site by design: an identity provider posts its assertion back to Jahia on *.saml */
+    private static final List<Pattern> BUILT_IN_WHITELIST = Collections.singletonList(JahiaCsrfGuardConfig.createUrlPattern("*.saml"));
 
     // AtomicReference (a thread-safe type) rather than a volatile reference: configs is re-bound (DYNAMIC reference)
     // while request threads read it, globalConfig is set once before activation. A volatile non-primitive field

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
@@ -179,8 +179,8 @@ public class FetchMetadataFilter extends AbstractServletFilter {
      * bypassed for the current request
      */
     private boolean isWhiteListed(ServletRequest request) {
-        String uri = JahiaCsrfGuardConfig.normalizePath(((HttpServletRequest) request).getRequestURI());
-        return BUILT_IN_WHITELIST.stream().anyMatch(pattern -> pattern.matcher(uri).matches())
+        String path = JahiaCsrfGuardConfig.resolvedPath((HttpServletRequest) request);
+        return BUILT_IN_WHITELIST.stream().anyMatch(pattern -> pattern.matcher(path).matches())
                 || configs.get().stream().anyMatch(config -> config.isCrossSiteWriteWhiteListed(request));
     }
 

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
@@ -55,8 +55,12 @@ public class FetchMetadataFilter extends AbstractServletFilter {
 
     private static final Set<String> WRITE_METHODS = new HashSet<>(Arrays.asList("POST", "PUT", "DELETE", "PATCH"));
 
-    /** URLs reached from another site by design: an identity provider posts its assertion back to Jahia on *.saml */
-    private static final List<Pattern> BUILT_IN_WHITELIST = Collections.singletonList(JahiaCsrfGuardConfig.createUrlPattern("*.saml"));
+    /**
+     * URLs reached from another site by design: an identity provider posts its assertion back to Jahia on the callback
+     * URL its SAML support serves, and that URL is the one endpoint of that support a write arrives on. This mirrors the
+     * condition the SAML filter dispatches on, so the exemption covers the endpoint that needs it and no other URL.
+     */
+    private static final List<Pattern> BUILT_IN_WHITELIST = Collections.singletonList(JahiaCsrfGuardConfig.createUrlPattern("*callback.saml"));
 
     // AtomicReference (a thread-safe type) rather than a volatile reference: configs is re-bound (DYNAMIC reference)
     // while request threads read it, globalConfig is set once before activation. A volatile non-primitive field

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfigTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfigTest.java
@@ -58,6 +58,15 @@ public class JahiaCsrfGuardConfigTest {
     }
 
     @Test
+    public void aPrefixPatternSelectsThePathItNames() {
+        JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.URL_PATTERNS, "/cms/*");
+        assertTrue(config.isFiltered(mapped("/cms", "/render/default/en/sites/site/home.html")));
+        // the two prefix forms docs/README.md gives as examples select the path they name, with or without its slash
+        assertTrue(config.isFiltered(mapped("/cms", "/")));
+        assertTrue(config.isFiltered(mapped("/cms", null)));
+    }
+
+    @Test
     public void matchingCarriesTheContextPath() {
         JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.URL_PATTERNS, "/jahia/cms/*");
         // A deployment under a context path keeps the URLs its patterns were written against

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfigTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfigTest.java
@@ -31,20 +31,38 @@ public class JahiaCsrfGuardConfigTest {
     }
 
     @Test
-    public void urlPatternMatchingNormalizesMatrixParameters() {
+    public void urlPatternMatchingOnARawUriDropsMatrixParameters() {
         JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.URL_PATTERNS, "*.do");
-        // a matrix parameter no longer hides the .do suffix the pattern selects
+        // A matrix parameter does not hide the .do suffix the pattern selects. These requests carry no servlet mapping,
+        // so they are matched on the raw URI, which is where a `;` delimits path parameters.
         assertTrue(config.isFiltered(request("/home.logAction.do;jsessionid=abc")));
         assertTrue(config.isFiltered(request("/home.logAction.do")));
     }
 
     @Test
-    public void whitelistMatchingCannotBeForgedByAMatrixParameter() {
+    public void whitelistMatchingOnARawUriCannotBeForgedByAMatrixParameter() {
         JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.WHITELIST, "*.saml");
-        // a request Jahia resolves to /home.html must not borrow the *.saml exemption through a matrix parameter
+        // A request Jahia resolves to /home.html must not borrow the *.saml exemption through a matrix parameter
         assertFalse(config.isWhiteListed(request("/sites/site/home.html;x=.saml")));
         assertTrue(config.isWhiteListed(request("/sites/site/home.callback.saml")));
         assertTrue(config.isWhiteListed(request("/sites/site/home.callback.saml;jsessionid=abc")));
+    }
+
+    @Test
+    public void urlPatternMatchingOnAMappedPathKeepsASemicolonInsideASegment() {
+        JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.URL_PATTERNS, "*.do");
+        // On a mapped path the container has already parsed path parameters out, so a `;` is a character the segment
+        // name contains — it must not shorten the path and take the suffix the pattern selects with it.
+        assertTrue(config.isFiltered(mapped("", "/en/sites/site/home;x.logAction.do")));
+        assertTrue(config.isFiltered(mapped("", "/en/sites/site/home;x.logAction.do/")));
+    }
+
+    @Test
+    public void matchingCarriesTheContextPath() {
+        JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.URL_PATTERNS, "/jahia/cms/*");
+        // A deployment under a context path keeps the URLs its patterns were written against
+        assertTrue(config.isFiltered(mapped("/jahia", "/cms", "/render/default/en/sites/site/home.logAction.do")));
+        assertFalse(config.isFiltered(mapped("", "/cms", "/render/default/en/sites/site/home.logAction.do")));
     }
 
     @Test
@@ -69,7 +87,9 @@ public class JahiaCsrfGuardConfigTest {
 
     @Test
     public void resolvedPathReadsTheMappedPathAndFallsBackToTheRawUri() {
-        // the servlet path and path info are what the container mapped: decoded, /./ and // collapsed
+        // These mocks stand in for what the container hands a servlet. That it hands over a decoded path with /./ and
+        // // already folded is a property of the container, asserted nowhere here — the javadoc on resolvedPath states
+        // it, and the module's e2e suite is what exercises it.
         assertEquals("/cms/render/en/home.publish.do", JahiaCsrfGuardConfig.resolvedPath(mapped("/cms", "/render/en/home.publish.do/")));
         // a request with no servlet mapping to read is matched on its raw URI, as before
         assertEquals("/en/home.publish.do", JahiaCsrfGuardConfig.resolvedPath(request("/en/home.publish.do/")));
@@ -86,13 +106,15 @@ public class JahiaCsrfGuardConfigTest {
     }
 
     @Test
-    public void shippedUrlPatternsSelectWhatTheirWordingSays() {
+    public void createUrlPatternReadsAnEscapedAsteriskAsALiteral() {
         assertTrue(JahiaCsrfGuardConfig.createUrlPattern("*.do").matcher("/en/sites/site/home.publish.do").matches());
         assertFalse(JahiaCsrfGuardConfig.createUrlPattern("*.do").matcher("/en/sites/site/home.html").matches());
-        // the second shipped pattern ends in a backslash-escaped asterisk, so it selects a literal "/*" suffix
+        // A pattern whose asterisk is backslash-escaped selects that asterisk as a character: this compiles to a
+        // literal "/*" suffix. The escape count a .cfg file has to carry for the value to arrive in this shape is a
+        // separate question, tracked in #175 — this pins the compiler, not the configuration file.
         Pattern literalStar = JahiaCsrfGuardConfig.createUrlPattern("*/\\*");
         assertTrue(literalStar.matcher("/en/sites/site/*").matches());
-        assertFalse(literalStar.matcher("/en/sites/site/").matches());
+        assertFalse(literalStar.matcher("/en/sites/site/x").matches());
     }
 
     private static JahiaCsrfGuardConfig config(String property, String value) {
@@ -108,9 +130,15 @@ public class JahiaCsrfGuardConfigTest {
         return request;
     }
 
-    /** a request as the container mapped it, the way a servlet reads it */
+    /** a request as the container mapped it, the way a servlet reads it, on a root-context deployment */
     private static HttpServletRequest mapped(String servletPath, String pathInfo) {
+        return mapped("", servletPath, pathInfo);
+    }
+
+    /** a request as the container mapped it, under the given context path */
+    private static HttpServletRequest mapped(String contextPath, String servletPath, String pathInfo) {
         HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getContextPath()).thenReturn(contextPath);
         when(request.getServletPath()).thenReturn(servletPath);
         when(request.getPathInfo()).thenReturn(pathInfo);
         return request;

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfigTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfigTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -13,9 +14,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Pins the matrix-parameter normalization that {@link JahiaCsrfGuardConfig#matches} now applies. Because the existing
- * token filter's {@code isFiltered}/{@code isWhiteListed} route through the same helper, this normalization also shifts
- * their matching — a matrix-param URI is matched on the path Jahia resolves, not on the raw request URI.
+ * Pins the path a pattern is matched against: the path Jahia resolves, not the raw request URI. All four matchers —
+ * the token filter's {@code isFiltered}/{@code isWhiteListed} and the fetch metadata policy's two — route through the
+ * same helper, so every case here holds for both. Two URLs Jahia serves as one must select the same patterns: a matrix
+ * parameter does not hide a suffix, and a trailing slash does not hide one either.
  */
 public class JahiaCsrfGuardConfigTest {
 
@@ -45,15 +47,72 @@ public class JahiaCsrfGuardConfigTest {
         assertTrue(config.isWhiteListed(request("/sites/site/home.callback.saml;jsessionid=abc")));
     }
 
+    @Test
+    public void urlPatternMatchingIgnoresATrailingSlash() {
+        JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.URL_PATTERNS, "*.do");
+        // Jahia serves these three spellings as one action, so the pattern that selects one selects them all
+        assertTrue(config.isFiltered(mapped("/cms", "/render/default/en/sites/site/home.logAction.do")));
+        assertTrue(config.isFiltered(mapped("/cms", "/render/default/en/sites/site/home.logAction.do/")));
+        assertTrue(config.isFiltered(mapped("/cms", "/render/default/en/sites/site/home.logAction.do//")));
+        assertFalse(config.isFiltered(mapped("/cms", "/render/default/en/sites/site/home.html")));
+    }
+
+    @Test
+    public void whitelistMatchingCoversTheSameActionReachedWithATrailingSlash() {
+        JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.WHITELIST, "*.logAction.do");
+        assertTrue(config.isWhiteListed(mapped("", "/en/sites/site/home.logAction.do")));
+        assertTrue(config.isWhiteListed(mapped("", "/en/sites/site/home.logAction.do/")));
+        // the exemption stays attached to the action it names
+        assertFalse(config.isWhiteListed(mapped("", "/en/sites/site/home.publish.do")));
+        assertFalse(config.isWhiteListed(mapped("", "/en/sites/site/home.publish.do/")));
+    }
+
+    @Test
+    public void resolvedPathReadsTheMappedPathAndFallsBackToTheRawUri() {
+        // the servlet path and path info are what the container mapped: decoded, /./ and // collapsed
+        assertEquals("/cms/render/en/home.publish.do", JahiaCsrfGuardConfig.resolvedPath(mapped("/cms", "/render/en/home.publish.do/")));
+        // a request with no servlet mapping to read is matched on its raw URI, as before
+        assertEquals("/en/home.publish.do", JahiaCsrfGuardConfig.resolvedPath(request("/en/home.publish.do/")));
+        assertEquals("/en/home.publish.do", JahiaCsrfGuardConfig.resolvedPath(request("/en/home.publish.do;jsessionid=abc/")));
+    }
+
+    @Test
+    public void stripTrailingSlashesKeepsARootPath() {
+        assertEquals("/", JahiaCsrfGuardConfig.stripTrailingSlashes("/"));
+        assertEquals("/", JahiaCsrfGuardConfig.stripTrailingSlashes("///"));
+        assertEquals("/a", JahiaCsrfGuardConfig.stripTrailingSlashes("/a//"));
+        assertEquals("/a/b", JahiaCsrfGuardConfig.stripTrailingSlashes("/a/b"));
+        assertEquals("", JahiaCsrfGuardConfig.stripTrailingSlashes(""));
+    }
+
+    @Test
+    public void shippedUrlPatternsSelectWhatTheirWordingSays() {
+        assertTrue(JahiaCsrfGuardConfig.createUrlPattern("*.do").matcher("/en/sites/site/home.publish.do").matches());
+        assertFalse(JahiaCsrfGuardConfig.createUrlPattern("*.do").matcher("/en/sites/site/home.html").matches());
+        // the second shipped pattern ends in a backslash-escaped asterisk, so it selects a literal "/*" suffix
+        Pattern literalStar = JahiaCsrfGuardConfig.createUrlPattern("*/\\*");
+        assertTrue(literalStar.matcher("/en/sites/site/*").matches());
+        assertFalse(literalStar.matcher("/en/sites/site/").matches());
+    }
+
     private static JahiaCsrfGuardConfig config(String property, String value) {
         Dictionary<String, Object> properties = new Hashtable<>();
         properties.put(property, value);
         return JahiaCsrfGuardConfig.build("org.jahia.modules.jahiacsrfguard-test", properties);
     }
 
+    /** a request the container could not map to a servlet: only its raw URI can be read */
     private static HttpServletRequest request(String uri) {
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getRequestURI()).thenReturn(uri);
+        return request;
+    }
+
+    /** a request as the container mapped it, the way a servlet reads it */
+    private static HttpServletRequest mapped(String servletPath, String pathInfo) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getServletPath()).thenReturn(servletPath);
+        when(request.getPathInfo()).thenReturn(pathInfo);
         return request;
     }
 }

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
@@ -177,17 +177,6 @@ public class FetchMetadataFilterTest {
         assertFalse(filter.isRejected(request("POST", "/sites/site/home.callback.saml", null, "cross-site")));
     }
 
-    @Test
-    public void theBuiltInExemptionCoversTheCallbackAndNoOtherUrl() {
-        filter.clearConfigs(mock(JahiaCsrfGuardConfigFactory.class));
-        // The exemption the module applies on its own names one endpoint. The other URLs that SAML support serves are
-        // read requests, which this policy does not cover, so they need no exemption and do not get one.
-        assertTrue(filter.isRejected(request("POST", "/sites/site/home.saml", null, "cross-site")));
-        assertTrue(filter.isRejected(request("POST", "/sites/site/home.connect.saml", null, "cross-site")));
-        assertTrue(filter.isRejected(request("POST", "/sites/site/home.metadata.saml", null, "cross-site")));
-        assertTrue(filter.isRejected(request("GET", "/sites/site/home.saml", "jcrMethodToCall=put", "cross-site")));
-    }
-
     // --- fixtures ---------------------------------------------------------------------------------------------------
 
     private static HttpServletRequest request(String method, String uri, String queryString, String secFetchSite) {

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
@@ -171,6 +171,27 @@ public class FetchMetadataFilterTest {
         assertTrue(filter.isRejected(request("POST", "/cms/render/live/fr/home", null, "cross-site")));
     }
 
+    // --- the branch a served request takes: the path the container mapped ---------------------------------------------
+
+    @Test
+    public void onAMappedPathACrossSiteWriteIsRejected() {
+        assertTrue(filter.isRejected(mapped("POST", "/cms", "/render/default/en/sites/site/home", null, "cross-site")));
+        assertTrue(filter.isRejected(mapped("GET", "/cms", "/render/default/en/sites/site/home", "jcrMethodToCall=put", "cross-site")));
+        assertFalse(filter.isRejected(mapped("POST", "/cms", "/render/default/en/sites/site/home", null, "same-origin")));
+    }
+
+    @Test
+    public void onAMappedPathATrailingSlashDoesNotChangeTheDecision() {
+        assertTrue(filter.isRejected(mapped("POST", "/cms", "/render/default/en/sites/site/home/", null, "cross-site")));
+        assertTrue(filter.isRejected(mapped("POST", "/cms", "/render/default/en/sites/site/home//", null, "cross-site")));
+    }
+
+    @Test
+    public void onAMappedPathTheExemptionIsRead() {
+        assertFalse(filter.isRejected(mapped("POST", "", "/sites/site/home.callback.saml", null, "cross-site")));
+        assertFalse(filter.isRejected(mapped("POST", "", "/sites/site/home.callback.saml/", null, "cross-site")));
+    }
+
     @Test
     public void withoutConfigurationTheSamlCallbackIsServed() {
         filter.clearConfigs(mock(JahiaCsrfGuardConfigFactory.class));
@@ -179,10 +200,23 @@ public class FetchMetadataFilterTest {
 
     // --- fixtures ---------------------------------------------------------------------------------------------------
 
+    /** a request the container mapped to no servlet: the policy reads its raw URI */
     private static HttpServletRequest request(String method, String uri, String queryString, String secFetchSite) {
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getMethod()).thenReturn(method);
         when(request.getRequestURI()).thenReturn(uri);
+        when(request.getQueryString()).thenReturn(queryString);
+        when(request.getHeader(FetchMetadataFilter.SEC_FETCH_SITE_HEADER)).thenReturn(secFetchSite);
+        return request;
+    }
+
+    /** a request as the container mapped it, which is the branch a served request takes */
+    private static HttpServletRequest mapped(String method, String servletPath, String pathInfo, String queryString, String secFetchSite) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn(method);
+        when(request.getContextPath()).thenReturn("");
+        when(request.getServletPath()).thenReturn(servletPath);
+        when(request.getPathInfo()).thenReturn(pathInfo);
         when(request.getQueryString()).thenReturn(queryString);
         when(request.getHeader(FetchMetadataFilter.SEC_FETCH_SITE_HEADER)).thenReturn(secFetchSite);
         return request;

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
@@ -177,6 +177,17 @@ public class FetchMetadataFilterTest {
         assertFalse(filter.isRejected(request("POST", "/sites/site/home.callback.saml", null, "cross-site")));
     }
 
+    @Test
+    public void theBuiltInExemptionCoversTheCallbackAndNoOtherUrl() {
+        filter.clearConfigs(mock(JahiaCsrfGuardConfigFactory.class));
+        // The exemption the module applies on its own names one endpoint. The other URLs that SAML support serves are
+        // read requests, which this policy does not cover, so they need no exemption and do not get one.
+        assertTrue(filter.isRejected(request("POST", "/sites/site/home.saml", null, "cross-site")));
+        assertTrue(filter.isRejected(request("POST", "/sites/site/home.connect.saml", null, "cross-site")));
+        assertTrue(filter.isRejected(request("POST", "/sites/site/home.metadata.saml", null, "cross-site")));
+        assertTrue(filter.isRejected(request("GET", "/sites/site/home.saml", "jcrMethodToCall=put", "cross-site")));
+    }
+
     // --- fixtures ---------------------------------------------------------------------------------------------------
 
     private static HttpServletRequest request(String method, String uri, String queryString, String secFetchSite) {

--- a/tests/cypress/e2e/configTest.cy.ts
+++ b/tests/cypress/e2e/configTest.cy.ts
@@ -32,6 +32,22 @@ describe('Config CSRF tests', () => {
         cy.logout();
     });
 
+    // Jahia serves /home.logAction.do/ as the action /home.logAction.do — its resolver drops the trailing slash — so
+    // a configuration that names that action must decide the same way for both forms of its url.
+    it('should decide on a url that only differs by a trailing slash the same way', () => {
+        cy.login();
+        const actionUrl = '/en/sites/' + targetSiteKey + '/home.logAction.do';
+        // exempt from token validation: both forms are served
+        cy.request({method: 'POST', url: actionUrl, failOnStatusCode: true}).its('status').should('equal', 200);
+        cy.request({method: 'POST', url: actionUrl + '/', failOnStatusCode: true}).its('status').should('equal', 200);
+        updateCsrfGuardWhiteListConfig('*.toto.do');
+        // covered by token validation: the plain form answers 400, which is what makes the next line meaningful
+        cy.request({method: 'POST', url: actionUrl, failOnStatusCode: false}).its('status').should('equal', 400);
+        cy.request({method: 'POST', url: actionUrl + '/', failOnStatusCode: false}).its('status').should('equal', 400);
+        updateCsrfGuardWhiteListConfig('*.logAction.do');
+        cy.logout();
+    });
+
     after('Clean', () => {
         updateCsrfGuardWhiteListConfig('*.logAction.do');
         deleteSite(targetSiteKey);

--- a/tests/cypress/e2e/configTest.cy.ts
+++ b/tests/cypress/e2e/configTest.cy.ts
@@ -37,7 +37,8 @@ describe('Config CSRF tests', () => {
     it('should decide on a url that only differs by a trailing slash the same way', () => {
         cy.login();
         const actionUrl = '/en/sites/' + targetSiteKey + '/home.logAction.do';
-        // Exempt from token validation: both forms are served
+        // Smoke check — the action answers on both forms of its url. Both are served on any build, so this pair
+        // does not discriminate; the 400s below are the assertion that does.
         cy.request({method: 'POST', url: actionUrl, failOnStatusCode: true}).its('status').should('equal', 200);
         cy.request({method: 'POST', url: actionUrl + '/', failOnStatusCode: true}).its('status').should('equal', 200);
         updateCsrfGuardWhiteListConfig('*.toto.do');

--- a/tests/cypress/e2e/configTest.cy.ts
+++ b/tests/cypress/e2e/configTest.cy.ts
@@ -37,11 +37,11 @@ describe('Config CSRF tests', () => {
     it('should decide on a url that only differs by a trailing slash the same way', () => {
         cy.login();
         const actionUrl = '/en/sites/' + targetSiteKey + '/home.logAction.do';
-        // exempt from token validation: both forms are served
+        // Exempt from token validation: both forms are served
         cy.request({method: 'POST', url: actionUrl, failOnStatusCode: true}).its('status').should('equal', 200);
         cy.request({method: 'POST', url: actionUrl + '/', failOnStatusCode: true}).its('status').should('equal', 200);
         updateCsrfGuardWhiteListConfig('*.toto.do');
-        // covered by token validation: the plain form answers 400, which is what makes the next line meaningful
+        // Covered by token validation: the plain form answers 400, which is what makes the next line meaningful
         cy.request({method: 'POST', url: actionUrl, failOnStatusCode: false}).its('status').should('equal', 400);
         cy.request({method: 'POST', url: actionUrl + '/', failOnStatusCode: false}).its('status').should('equal', 400);
         updateCsrfGuardWhiteListConfig('*.logAction.do');


### PR DESCRIPTION
## Summary

A module configuration selects requests by their URL, and Jahia serves several spellings of one URL as one resource: the container decodes the path, folds `/./` and repeated slashes, resolves `/../` and parses path parameters out, and Jahia's URLResolver drops a trailing slash before the render pipeline reads a path. Matching now happens on that resolved path, so a `urlPatterns` or `whitelist` entry covers every spelling of the URL it names.

This continues the normalization introduced with the fetch metadata request policy, which already compared patterns against the path without its matrix parameters.

## Change

- `JahiaCsrfGuardConfig.resolvedPath()` composes the path the container mapped (`getServletPath()` + `getPathInfo()`), puts the context path back in front of it, and drops trailing slashes.
- A pattern is tested against that path and against the path as a directory, so a prefix pattern still selects the path it names: `/cms/*` compiles to `/cms/.*`, whose shortest match is `/cms/`.
- The matrix-parameter strip applies to a **raw URI** only, which is where a `;` delimits path parameters. On a mapped path the container has already parsed them out, so a `;` there is part of a segment's name and stripping from it would cut the path short.
- All four matchers go through it: `urlPatterns` and `whitelist` used by token validation, and `crossSiteWriteUrlPatterns` / `crossSiteWriteWhitelist` used by the fetch metadata request policy, including the module's built-in exemption.
- A request the container mapped to no servlet is matched on its raw URI.
- `docs/README.md` states which path patterns are compared against, in both the whitelist and the fetch metadata sections.
- `Render` reads `getServletPath()` / `getPathInfo()` itself, so this puts the matcher on the same input as the dispatcher it protects.

## Verification

- `mvn test` — 45 tests green. The 21 pre-existing fetch metadata cases pass unchanged, and they read a raw URI, so they are not evidence about the mapped path; three new cases in that suite cover the branch a served request takes, including the exemption read on a resolved path.
- Unit cases in `JahiaCsrfGuardConfigTest` pin: one pattern selecting every spelling of an action URL, a whitelist entry staying attached to the action it names, a `;` inside a segment of a mapped path, a deployment under a context path, the raw-URI fallback, root-path handling, and what an escaped asterisk in a pattern selects.
- e2e case in `configTest.cy.ts`: with the action outside the whitelist, both spellings of its URL answer `400`; with it inside, both answer `200`. The plain spelling's `400` is the control that shows token validation is active on that session, so the other assertion cannot pass vacuously. Measured both ways — the case fails on a build without this change.
- **Two lines, deployed and probed** (`curl --path-as-is`, decided on the module's own log rather than status codes, log window opened immediately before each request):
  - **8.2.3 maintenance line** (`jahia-ee-dev:8.2.3-SNAPSHOT`, core `8.2.3.3-SNAPSHOT`), against the released `4.2.0` the image ships: `…publish.do/` and `…publish.do//` go from unselected to selected, `…publish.do` is unchanged, a whitelisted `*.myAction.do` stays exempt.
  - **8.2.4.0-SNAPSHOT** (`jahia-ee-dev:8-SNAPSHOT`): same result, plus a plain page request untouched and the fetch metadata policy answering as it did — cross-site write `403`, same-origin and same-site writes served, cross-site read served.
- **What the probes do not show, stated plainly:** `/./`, `%2E`, `;` and `%3B` answer `400` before any module filter on **both** lines — on 8.2.4.0 from core's `MalformedUrlFilter`, and on the 8.2.3 line from a global request check that answers the same way for a static resource (`GET /css/errors%2Ecss` → `400`). No probe can exercise the part of this change that covers those spellings. It is there so the matcher does not depend on that layer staying configured as it is (its non-ASCII arm is already off), and the trailing-slash family is the part demonstrated end to end.
