### PR TITLE
fix: scope the built-in exemption to the SAML callback URL

### DIFF
--- a/.chachalog/v9DD9C4r.md
+++ b/.chachalog/v9DD9C4r.md
@@ -1,0 +1,5 @@
+---
+jahia-csrf-guard: patch
+---
+
+Scoped the exemption the module applies on its own to the SAML callback URL, `*callback.saml`.

--- a/.chachalog/v9DD9C4r.md
+++ b/.chachalog/v9DD9C4r.md
@@ -3,3 +3,5 @@ jahia-csrf-guard: patch
 ---
 
 Scoped the exemption the module applies on its own to the SAML callback URL, `*callback.saml`.
+
+A site whose identity provider returns its response to another URL must list that URL in the `crossSiteWriteWhitelist` property of a module configuration. The setting to check is **Incoming Target Url**, whose default is `/home.callback.saml`.

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
@@ -55,8 +55,12 @@ public class FetchMetadataFilter extends AbstractServletFilter {
 
     private static final Set<String> WRITE_METHODS = new HashSet<>(Arrays.asList("POST", "PUT", "DELETE", "PATCH"));
 
-    /** URLs reached from another site by design: an identity provider posts its assertion back to Jahia on *.saml */
-    private static final List<Pattern> BUILT_IN_WHITELIST = Collections.singletonList(JahiaCsrfGuardConfig.createUrlPattern("*.saml"));
+    /**
+     * URLs reached from another site by design: an identity provider posts its assertion back to Jahia on the callback
+     * URL its SAML support serves, and that URL is the one endpoint of that support a write arrives on. This mirrors the
+     * condition the SAML filter dispatches on, so the exemption covers the endpoint that needs it and no other URL.
+     */
+    private static final List<Pattern> BUILT_IN_WHITELIST = Collections.singletonList(JahiaCsrfGuardConfig.createUrlPattern("*callback.saml"));
 
     // AtomicReference (a thread-safe type) rather than a volatile reference: configs is re-bound (DYNAMIC reference)
     // while request threads read it, globalConfig is set once before activation. A volatile non-primitive field

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
@@ -177,6 +177,17 @@ public class FetchMetadataFilterTest {
         assertFalse(filter.isRejected(request("POST", "/sites/site/home.callback.saml", null, "cross-site")));
     }
 
+    @Test
+    public void theBuiltInExemptionCoversTheCallbackAndNoOtherUrl() {
+        filter.clearConfigs(mock(JahiaCsrfGuardConfigFactory.class));
+        // The exemption the module applies on its own names one endpoint. The other URLs that SAML support serves are
+        // read requests, which this policy does not cover, so they need no exemption and do not get one.
+        assertTrue(filter.isRejected(request("POST", "/sites/site/home.saml", null, "cross-site")));
+        assertTrue(filter.isRejected(request("POST", "/sites/site/home.connect.saml", null, "cross-site")));
+        assertTrue(filter.isRejected(request("POST", "/sites/site/home.metadata.saml", null, "cross-site")));
+        assertTrue(filter.isRejected(request("GET", "/sites/site/home.saml", "jcrMethodToCall=put", "cross-site")));
+    }
+
     // --- fixtures ---------------------------------------------------------------------------------------------------
 
     private static HttpServletRequest request(String method, String uri, String queryString, String secFetchSite) {


### PR DESCRIPTION
## Summary

The fetch metadata request policy exempts the URL an identity provider posts its response back to. That exemption is the one entry the module applies on its own, without configuration, so it should name the endpoint it exists for.

It now names `*callback.saml`, which is the condition the SAML support dispatches that endpoint on.

## Change

- `FetchMetadataFilter.BUILT_IN_WHITELIST` holds `*callback.saml`.
- `SAML2Filter` in `saml-authentication-valve` dispatches on three URLs — `connect.saml`, `callback.saml` and `metadata.saml` — and the callback is the one a content change arrives on: it is the **Incoming Target Url**, whose `bindingType` defaults to HTTP-POST. `connect.saml` is a GET, in the module's own login form and in its documented links, and `metadata.saml` is a read. This policy covers content changes only, so those two keep working with no exemption.
- Guard and endpoint therefore agree on one condition, which is the property `#181` applies to configured patterns, applied here to the entry that ships with the module.
- A site whose identity provider returns its response to another URL lists that URL in `crossSiteWriteWhitelist`. The changelog fragment says so, because **Incoming Target Url** is configurable.

## Verification

- `mvn test` — green, with a new case pinning which URLs the built-in entry covers: a cross-site content change is refused on `…/home.saml`, `…/home.connect.saml` and `…/home.metadata.saml`, and on a `GET …/home.saml?jcrMethodToCall=put`. Every existing fetch metadata case passes untouched, including the two that exercise the callback.
- Deployed on a local `8-SNAPSHOT` and probed with a logged-in session, an `Origin` on another host and `Sec-Fetch-Site: cross-site`: a content change answers `403` on `…/home.saml`, `…/home.connect.saml`, `…/home.metadata.saml` and `/foo/bar.saml`, and reaches the endpoint on `…/home.callback.saml`.
- The control that makes those `403`s attributable: the same content change from a same-origin context is still served on a `.saml` URL, so what changed is the policy's scope and not the route.
