### PR TITLE
fix: scope the built-in exemption to the SAML callback URL

### DIFF
--- a/.chachalog/UHErOM.md
+++ b/.chachalog/UHErOM.md
@@ -1,0 +1,5 @@
+---
+jahia-csrf-guard: patch
+---
+
+Scoped the exemption the module applies on its own to the SAML callback URL, `*callback.saml`.

--- a/.chachalog/UHErOM.md
+++ b/.chachalog/UHErOM.md
@@ -3,3 +3,5 @@ jahia-csrf-guard: patch
 ---
 
 Scoped the exemption the module applies on its own to the SAML callback URL, `*callback.saml`.
+
+A site whose identity provider returns its response to another URL must list that URL in the `crossSiteWriteWhitelist` property of a module configuration. The setting to check is **Incoming Target Url**, whose default is `/home.callback.saml`.

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
@@ -55,8 +55,12 @@ public class FetchMetadataFilter extends AbstractServletFilter {
 
     private static final Set<String> WRITE_METHODS = new HashSet<>(Arrays.asList("POST", "PUT", "DELETE", "PATCH"));
 
-    /** URLs reached from another site by design: an identity provider posts its assertion back to Jahia on *.saml */
-    private static final List<Pattern> BUILT_IN_WHITELIST = Collections.singletonList(JahiaCsrfGuardConfig.createUrlPattern("*.saml"));
+    /**
+     * URLs reached from another site by design: an identity provider posts its assertion back to Jahia on the callback
+     * URL its SAML support serves, and that URL is the one endpoint of that support a write arrives on. This mirrors the
+     * condition the SAML filter dispatches on, so the exemption covers the endpoint that needs it and no other URL.
+     */
+    private static final List<Pattern> BUILT_IN_WHITELIST = Collections.singletonList(JahiaCsrfGuardConfig.createUrlPattern("*callback.saml"));
 
     // AtomicReference (a thread-safe type) rather than a volatile reference: configs is re-bound (DYNAMIC reference)
     // while request threads read it, globalConfig is set once before activation. A volatile non-primitive field

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
@@ -177,6 +177,17 @@ public class FetchMetadataFilterTest {
         assertFalse(filter.isRejected(request("POST", "/sites/site/home.callback.saml", null, "cross-site")));
     }
 
+    @Test
+    public void theBuiltInExemptionCoversTheCallbackAndNoOtherUrl() {
+        filter.clearConfigs(mock(JahiaCsrfGuardConfigFactory.class));
+        // The exemption the module applies on its own names one endpoint. The other URLs that SAML support serves are
+        // read requests, which this policy does not cover, so they need no exemption and do not get one.
+        assertTrue(filter.isRejected(request("POST", "/sites/site/home.saml", null, "cross-site")));
+        assertTrue(filter.isRejected(request("POST", "/sites/site/home.connect.saml", null, "cross-site")));
+        assertTrue(filter.isRejected(request("POST", "/sites/site/home.metadata.saml", null, "cross-site")));
+        assertTrue(filter.isRejected(request("GET", "/sites/site/home.saml", "jcrMethodToCall=put", "cross-site")));
+    }
+
     // --- fixtures ---------------------------------------------------------------------------------------------------
 
     private static HttpServletRequest request(String method, String uri, String queryString, String secFetchSite) {


### PR DESCRIPTION
## Summary

Carries the change merged on `main` in #182 to this maintenance line: the exemption the module applies on its own names `*callback.saml`, the URL its SAML support serves content changes on, rather than the `.saml` suffix.

## Change

Cherry-pick of `35ba6d2`, unchanged. The SAML support dispatches on three URLs — `connect.saml`, `callback.saml` and `metadata.saml` — and the callback is the one a content change arrives on: it is the **Incoming Target Url**, whose `bindingType` defaults to HTTP-POST. The other two are read requests, which the fetch metadata request policy does not cover, so they keep working with no exemption. A site whose identity provider returns its response to another URL lists that URL in `crossSiteWriteWhitelist`.

## Verification

`mvn test` on this line — 35 tests green, the fetch metadata suite among them, including the case that pins which URLs the built-in entry covers. The change applied without conflict, so it is byte-identical to what `main` carries.
