### PR TITLE
fix: match url patterns against the resolved request path

### DIFF
--- a/.chachalog/mxCloo.md
+++ b/.chachalog/mxCloo.md
@@ -1,0 +1,5 @@
+---
+jahia-csrf-guard: patch
+---
+
+Matched URL patterns and whitelists against the resolved path, so an entry covers every spelling of the URL it names.

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfig.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfig.java
@@ -154,15 +154,61 @@ public class JahiaCsrfGuardConfig {
         if (patterns == null) {
             return false;
         }
-        String uri = normalizePath(((HttpServletRequest) request).getRequestURI());
-        return patterns.stream().anyMatch(pattern -> pattern.matcher(uri).matches());
+        String path = resolvedPath((HttpServletRequest) request);
+        // A pattern is tested against the path and against the path as a directory, because a prefix pattern names its
+        // own root: `/cms/*` compiles to `/cms/.*`, whose shortest match is `/cms/`. Testing both spellings lets such a
+        // pattern select the path it names, whether or not the request spelled the slash.
+        String asDirectory = path.endsWith("/") ? path : path + "/";
+        return patterns.stream().anyMatch(pattern -> pattern.matcher(path).matches() || pattern.matcher(asDirectory).matches());
     }
 
     /**
-     * Strip the matrix parameters from every segment of a request URI, so a pattern is matched against the path Jahia
-     * resolves rather than the raw URI. Without this, a cross-site write to {@code /home.html;x=.saml} would end in
-     * {@code .saml}, match a {@code *.saml} whitelist and bypass the policy, while Jahia's Render dispatch drops the
-     * matrix parameter and still writes {@code /home.html}. The query string is not part of the URI, so it is untouched.
+     * The path a pattern is compared against: the one the container resolved for this request, so that the spellings
+     * Jahia serves as a single resource are matched as a single resource. Jahia's URLResolver drops a trailing slash
+     * before the render pipeline reads a path, which is what makes {@code /home.action.do/} and {@code /home.action.do}
+     * one URL to select, and the same holds for the other spellings the container folds away.
+     * <p>
+     * The servlet path and path info are what the container mapped: percent-decoded, with {@code /./} and repeated
+     * slashes collapsed, {@code /../} resolved and path parameters parsed out. The context path is put back in front of
+     * them, so a pattern keeps being written against the same URL it always was, and trailing slashes are dropped.
+     * <p>
+     * The matrix-parameter strip belongs to the raw URI, and applies only where the raw URI is what gets matched. On the
+     * mapped path a {@code ;} is content the container decoded from a {@code %3B}, part of a segment's name — dropping
+     * from it would cut the path short and take the suffix a pattern selects with it.
+     * <p>
+     * This is the path of the request being filtered. An internal forward, such as the one that serves a site URL
+     * through {@code /cms/render/…}, is a separate dispatch this filter is not registered for and never reads.
+     *
+     * @param request client request object for servlet
+     * @return the path the container resolved, never null
+     */
+    public static String resolvedPath(HttpServletRequest request) {
+        String mapped = StringUtils.defaultString(request.getServletPath()) + StringUtils.defaultString(request.getPathInfo());
+        if (StringUtils.isEmpty(mapped)) {
+            // nothing mapped to read: match the raw URI, where a `;` still delimits path parameters
+            return stripTrailingSlashes(normalizePath(request.getRequestURI()));
+        }
+        return stripTrailingSlashes(StringUtils.defaultString(request.getContextPath()) + mapped);
+    }
+
+    /**
+     * @param path a request path
+     * @return the path without the trailing slashes URLResolver drops, a bare {@code /} kept as is
+     */
+    static String stripTrailingSlashes(String path) {
+        int end = path.length();
+        while (end > 1 && path.charAt(end - 1) == '/') {
+            end--;
+        }
+        return path.substring(0, end);
+    }
+
+    /**
+     * Strip the matrix parameters from every segment of a raw request URI, the step {@link #resolvedPath} applies when a
+     * raw URI is what it has to match.
+     * Without this, a cross-site write to {@code /home.html;x=.saml} would end in {@code .saml}, match a {@code *.saml}
+     * whitelist and bypass the policy, while Jahia's Render dispatch drops the matrix parameter and still writes
+     * {@code /home.html}. The query string is not part of the URI, so it is untouched.
      *
      * @param uri a raw request URI, may be null
      * @return the URI with each segment's {@code ;matrix=params} removed

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
@@ -179,8 +179,8 @@ public class FetchMetadataFilter extends AbstractServletFilter {
      * bypassed for the current request
      */
     private boolean isWhiteListed(ServletRequest request) {
-        String uri = JahiaCsrfGuardConfig.normalizePath(((HttpServletRequest) request).getRequestURI());
-        return BUILT_IN_WHITELIST.stream().anyMatch(pattern -> pattern.matcher(uri).matches())
+        String path = JahiaCsrfGuardConfig.resolvedPath((HttpServletRequest) request);
+        return BUILT_IN_WHITELIST.stream().anyMatch(pattern -> pattern.matcher(path).matches())
                 || configs.get().stream().anyMatch(config -> config.isCrossSiteWriteWhiteListed(request));
     }
 

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfigTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardConfigTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -13,9 +14,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Pins the matrix-parameter normalization that {@link JahiaCsrfGuardConfig#matches} now applies. Because the existing
- * token filter's {@code isFiltered}/{@code isWhiteListed} route through the same helper, this normalization also shifts
- * their matching — a matrix-param URI is matched on the path Jahia resolves, not on the raw request URI.
+ * Pins the path a pattern is matched against: the path Jahia resolves, not the raw request URI. All four matchers —
+ * the token filter's {@code isFiltered}/{@code isWhiteListed} and the fetch metadata policy's two — route through the
+ * same helper, so every case here holds for both. Two URLs Jahia serves as one must select the same patterns: a matrix
+ * parameter does not hide a suffix, and a trailing slash does not hide one either.
  */
 public class JahiaCsrfGuardConfigTest {
 
@@ -29,20 +31,99 @@ public class JahiaCsrfGuardConfigTest {
     }
 
     @Test
-    public void urlPatternMatchingNormalizesMatrixParameters() {
+    public void urlPatternMatchingOnARawUriDropsMatrixParameters() {
         JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.URL_PATTERNS, "*.do");
-        // a matrix parameter no longer hides the .do suffix the pattern selects
+        // A matrix parameter does not hide the .do suffix the pattern selects. These requests carry no servlet mapping,
+        // so they are matched on the raw URI, which is where a `;` delimits path parameters.
         assertTrue(config.isFiltered(request("/home.logAction.do;jsessionid=abc")));
         assertTrue(config.isFiltered(request("/home.logAction.do")));
     }
 
     @Test
-    public void whitelistMatchingCannotBeForgedByAMatrixParameter() {
+    public void whitelistMatchingOnARawUriCannotBeForgedByAMatrixParameter() {
         JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.WHITELIST, "*.saml");
-        // a request Jahia resolves to /home.html must not borrow the *.saml exemption through a matrix parameter
+        // A request Jahia resolves to /home.html must not borrow the *.saml exemption through a matrix parameter
         assertFalse(config.isWhiteListed(request("/sites/site/home.html;x=.saml")));
         assertTrue(config.isWhiteListed(request("/sites/site/home.callback.saml")));
         assertTrue(config.isWhiteListed(request("/sites/site/home.callback.saml;jsessionid=abc")));
+    }
+
+    @Test
+    public void urlPatternMatchingOnAMappedPathKeepsASemicolonInsideASegment() {
+        JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.URL_PATTERNS, "*.do");
+        // On a mapped path the container has already parsed path parameters out, so a `;` is a character the segment
+        // name contains — it must not shorten the path and take the suffix the pattern selects with it.
+        assertTrue(config.isFiltered(mapped("", "/en/sites/site/home;x.logAction.do")));
+        assertTrue(config.isFiltered(mapped("", "/en/sites/site/home;x.logAction.do/")));
+    }
+
+    @Test
+    public void aPrefixPatternSelectsThePathItNames() {
+        JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.URL_PATTERNS, "/cms/*");
+        assertTrue(config.isFiltered(mapped("/cms", "/render/default/en/sites/site/home.html")));
+        // the two prefix forms docs/README.md gives as examples select the path they name, with or without its slash
+        assertTrue(config.isFiltered(mapped("/cms", "/")));
+        assertTrue(config.isFiltered(mapped("/cms", null)));
+    }
+
+    @Test
+    public void matchingCarriesTheContextPath() {
+        JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.URL_PATTERNS, "/jahia/cms/*");
+        // A deployment under a context path keeps the URLs its patterns were written against
+        assertTrue(config.isFiltered(mapped("/jahia", "/cms", "/render/default/en/sites/site/home.logAction.do")));
+        assertFalse(config.isFiltered(mapped("", "/cms", "/render/default/en/sites/site/home.logAction.do")));
+    }
+
+    @Test
+    public void urlPatternMatchingIgnoresATrailingSlash() {
+        JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.URL_PATTERNS, "*.do");
+        // Jahia serves these three spellings as one action, so the pattern that selects one selects them all
+        assertTrue(config.isFiltered(mapped("/cms", "/render/default/en/sites/site/home.logAction.do")));
+        assertTrue(config.isFiltered(mapped("/cms", "/render/default/en/sites/site/home.logAction.do/")));
+        assertTrue(config.isFiltered(mapped("/cms", "/render/default/en/sites/site/home.logAction.do//")));
+        assertFalse(config.isFiltered(mapped("/cms", "/render/default/en/sites/site/home.html")));
+    }
+
+    @Test
+    public void whitelistMatchingCoversTheSameActionReachedWithATrailingSlash() {
+        JahiaCsrfGuardConfig config = config(JahiaCsrfGuardConfig.WHITELIST, "*.logAction.do");
+        assertTrue(config.isWhiteListed(mapped("", "/en/sites/site/home.logAction.do")));
+        assertTrue(config.isWhiteListed(mapped("", "/en/sites/site/home.logAction.do/")));
+        // the exemption stays attached to the action it names
+        assertFalse(config.isWhiteListed(mapped("", "/en/sites/site/home.publish.do")));
+        assertFalse(config.isWhiteListed(mapped("", "/en/sites/site/home.publish.do/")));
+    }
+
+    @Test
+    public void resolvedPathReadsTheMappedPathAndFallsBackToTheRawUri() {
+        // These mocks stand in for what the container hands a servlet. That it hands over a decoded path with /./ and
+        // // already folded is a property of the container, asserted nowhere here — the javadoc on resolvedPath states
+        // it, and the module's e2e suite is what exercises it.
+        assertEquals("/cms/render/en/home.publish.do", JahiaCsrfGuardConfig.resolvedPath(mapped("/cms", "/render/en/home.publish.do/")));
+        // a request with no servlet mapping to read is matched on its raw URI, as before
+        assertEquals("/en/home.publish.do", JahiaCsrfGuardConfig.resolvedPath(request("/en/home.publish.do/")));
+        assertEquals("/en/home.publish.do", JahiaCsrfGuardConfig.resolvedPath(request("/en/home.publish.do;jsessionid=abc/")));
+    }
+
+    @Test
+    public void stripTrailingSlashesKeepsARootPath() {
+        assertEquals("/", JahiaCsrfGuardConfig.stripTrailingSlashes("/"));
+        assertEquals("/", JahiaCsrfGuardConfig.stripTrailingSlashes("///"));
+        assertEquals("/a", JahiaCsrfGuardConfig.stripTrailingSlashes("/a//"));
+        assertEquals("/a/b", JahiaCsrfGuardConfig.stripTrailingSlashes("/a/b"));
+        assertEquals("", JahiaCsrfGuardConfig.stripTrailingSlashes(""));
+    }
+
+    @Test
+    public void createUrlPatternReadsAnEscapedAsteriskAsALiteral() {
+        assertTrue(JahiaCsrfGuardConfig.createUrlPattern("*.do").matcher("/en/sites/site/home.publish.do").matches());
+        assertFalse(JahiaCsrfGuardConfig.createUrlPattern("*.do").matcher("/en/sites/site/home.html").matches());
+        // A pattern whose asterisk is backslash-escaped selects that asterisk as a character: this compiles to a
+        // literal "/*" suffix. The escape count a .cfg file has to carry for the value to arrive in this shape is a
+        // separate question, tracked in #175 — this pins the compiler, not the configuration file.
+        Pattern literalStar = JahiaCsrfGuardConfig.createUrlPattern("*/\\*");
+        assertTrue(literalStar.matcher("/en/sites/site/*").matches());
+        assertFalse(literalStar.matcher("/en/sites/site/x").matches());
     }
 
     private static JahiaCsrfGuardConfig config(String property, String value) {
@@ -51,9 +132,24 @@ public class JahiaCsrfGuardConfigTest {
         return JahiaCsrfGuardConfig.build("org.jahia.modules.jahiacsrfguard-test", properties);
     }
 
+    /** a request the container could not map to a servlet: only its raw URI can be read */
     private static HttpServletRequest request(String uri) {
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getRequestURI()).thenReturn(uri);
+        return request;
+    }
+
+    /** a request as the container mapped it, the way a servlet reads it, on a root-context deployment */
+    private static HttpServletRequest mapped(String servletPath, String pathInfo) {
+        return mapped("", servletPath, pathInfo);
+    }
+
+    /** a request as the container mapped it, under the given context path */
+    private static HttpServletRequest mapped(String contextPath, String servletPath, String pathInfo) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getContextPath()).thenReturn(contextPath);
+        when(request.getServletPath()).thenReturn(servletPath);
+        when(request.getPathInfo()).thenReturn(pathInfo);
         return request;
     }
 }

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
@@ -171,6 +171,27 @@ public class FetchMetadataFilterTest {
         assertTrue(filter.isRejected(request("POST", "/cms/render/live/fr/home", null, "cross-site")));
     }
 
+    // --- the branch a served request takes: the path the container mapped ---------------------------------------------
+
+    @Test
+    public void onAMappedPathACrossSiteWriteIsRejected() {
+        assertTrue(filter.isRejected(mapped("POST", "/cms", "/render/default/en/sites/site/home", null, "cross-site")));
+        assertTrue(filter.isRejected(mapped("GET", "/cms", "/render/default/en/sites/site/home", "jcrMethodToCall=put", "cross-site")));
+        assertFalse(filter.isRejected(mapped("POST", "/cms", "/render/default/en/sites/site/home", null, "same-origin")));
+    }
+
+    @Test
+    public void onAMappedPathATrailingSlashDoesNotChangeTheDecision() {
+        assertTrue(filter.isRejected(mapped("POST", "/cms", "/render/default/en/sites/site/home/", null, "cross-site")));
+        assertTrue(filter.isRejected(mapped("POST", "/cms", "/render/default/en/sites/site/home//", null, "cross-site")));
+    }
+
+    @Test
+    public void onAMappedPathTheExemptionIsRead() {
+        assertFalse(filter.isRejected(mapped("POST", "", "/sites/site/home.callback.saml", null, "cross-site")));
+        assertFalse(filter.isRejected(mapped("POST", "", "/sites/site/home.callback.saml/", null, "cross-site")));
+    }
+
     @Test
     public void withoutConfigurationTheSamlCallbackIsServed() {
         filter.clearConfigs(mock(JahiaCsrfGuardConfigFactory.class));
@@ -179,10 +200,23 @@ public class FetchMetadataFilterTest {
 
     // --- fixtures ---------------------------------------------------------------------------------------------------
 
+    /** a request the container mapped to no servlet: the policy reads its raw URI */
     private static HttpServletRequest request(String method, String uri, String queryString, String secFetchSite) {
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getMethod()).thenReturn(method);
         when(request.getRequestURI()).thenReturn(uri);
+        when(request.getQueryString()).thenReturn(queryString);
+        when(request.getHeader(FetchMetadataFilter.SEC_FETCH_SITE_HEADER)).thenReturn(secFetchSite);
+        return request;
+    }
+
+    /** a request as the container mapped it, which is the branch a served request takes */
+    private static HttpServletRequest mapped(String method, String servletPath, String pathInfo, String queryString, String secFetchSite) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn(method);
+        when(request.getContextPath()).thenReturn("");
+        when(request.getServletPath()).thenReturn(servletPath);
+        when(request.getPathInfo()).thenReturn(pathInfo);
         when(request.getQueryString()).thenReturn(queryString);
         when(request.getHeader(FetchMetadataFilter.SEC_FETCH_SITE_HEADER)).thenReturn(secFetchSite);
         return request;

--- a/tests/cypress/e2e/configTest.cy.ts
+++ b/tests/cypress/e2e/configTest.cy.ts
@@ -32,6 +32,23 @@ describe('Config CSRF tests', () => {
         cy.logout();
     });
 
+    // Jahia serves /home.logAction.do/ as the action /home.logAction.do — its resolver drops the trailing slash — so
+    // a configuration that names that action must decide the same way for both forms of its url.
+    it('should decide on a url that only differs by a trailing slash the same way', () => {
+        cy.login();
+        const actionUrl = '/en/sites/' + targetSiteKey + '/home.logAction.do';
+        // Smoke check — the action answers on both forms of its url. Both are served on any build, so this pair
+        // does not discriminate; the 400s below are the assertion that does.
+        cy.request({method: 'POST', url: actionUrl, failOnStatusCode: true}).its('status').should('equal', 200);
+        cy.request({method: 'POST', url: actionUrl + '/', failOnStatusCode: true}).its('status').should('equal', 200);
+        updateCsrfGuardWhiteListConfig('*.toto.do');
+        // Covered by token validation: the plain form answers 400, which is what makes the next line meaningful
+        cy.request({method: 'POST', url: actionUrl, failOnStatusCode: false}).its('status').should('equal', 400);
+        cy.request({method: 'POST', url: actionUrl + '/', failOnStatusCode: false}).its('status').should('equal', 400);
+        updateCsrfGuardWhiteListConfig('*.logAction.do');
+        cy.logout();
+    });
+
     after('Clean', () => {
         updateCsrfGuardWhiteListConfig('*.logAction.do');
         deleteSite(targetSiteKey);


### PR DESCRIPTION
## Summary

Carries the change merged on `main` in #181 to this maintenance line: a pattern is matched against the path the container resolved, so a `urlPatterns` or `whitelist` entry covers every spelling of the URL it names.

## Change

Cherry-pick of `d5103f3`, with two paths dropped because this line does not carry them:

- `docs/README.md` — the module's documentation lives here only on `main`.
- the changelog fragment — this PR writes its own.

Everything else applies unchanged: `resolvedPath()` composes the mapped path with the context path in front and trailing slashes dropped, the matrix strip stays on the raw-URI branch, a pattern is tested against the path and the path as a directory, and the exemption list is untouched — that one is #183's subject, and the two PRs are independent by design.

## Verification

`mvn test` on this line — **45 tests green**: 11 in `JahiaCsrfGuardConfigTest`, 24 in `FetchMetadataFilterTest`, 10 in `MultipartRequestWrapperTest`. The same counts as `main` carries after #181.

Note the integration-test check does not reach a spec on this branch: it hangs in `ci.startup.sh` and is cut by the job cap, as it was on #177 and #183. That is the branch's CI, not this cherry-pick — the same commit passed that suite on `main` before merge.

## Order

If #183 lands first, this branch needs a small rebase: both touch `FetchMetadataFilterTest`, in different methods.
