### PR TITLE
fix: restore compatibility with Java 8

### DIFF
--- a/.chachalog/JuKJz7YP.md
+++ b/.chachalog/JuKJz7YP.md
@@ -1,0 +1,8 @@
+---
+# Allowed version bumps: patch, minor, major
+jahia-csrf-guard: patch
+---
+
+Fixed the module so it works on a Jahia server that runs Java 8.
+
+On Java 8 the module started but protected no request, which left the site without CSRF protection. Jahia 8.1 supports Java 8, so a site that runs Jahia 8.1 on a Java 8 runtime was affected. Check the Java version of your Jahia server, and upgrade to this version of the module if that version is Java 8.

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -39,8 +39,8 @@ jobs:
     container:
       image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ secrets.GH_PACKAGES_USERNAME }}
+        password: ${{ secrets.GH_PACKAGES_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: jahia/jahia-modules-action/build@v2

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -37,7 +37,7 @@ jobs:
     env:
       NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }}
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
+      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -37,7 +37,7 @@ jobs:
     env:
       NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }}
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }}
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
+      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -110,7 +110,7 @@ jobs:
     env:
       NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }}
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_11.0.20-node
+      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }}
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -110,7 +110,7 @@ jobs:
     env:
       NEXUS_INTERNAL_URL: ${{ secrets.NEXUS_INTERNAL_URL }}
     container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
+      image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -31,8 +31,8 @@ jobs:
     container:
       image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ secrets.GH_PACKAGES_USERNAME }}
+        password: ${{ secrets.GH_PACKAGES_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: jahia/jahia-modules-action/build@v2
@@ -112,8 +112,8 @@ jobs:
     container:
       image: ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ secrets.GH_PACKAGES_USERNAME }}
+        password: ${{ secrets.GH_PACKAGES_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: jahia/jahia-modules-action/publish@v2

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -12,3 +12,4 @@ jobs:
     secrets: inherit
     with:
       primary_release_branch: 4_2_x
+      job_container: 'ghcr.io/jahia/jahia-docker-mvn-cache:8-jdk-noble-mvn-loaded'

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
 
     <properties>
         <csrfguard.version>4.5.0</csrfguard.version>
-        <jahia.plugin.version>6.12</jahia.plugin.version>
         <jahia-module-type>system</jahia-module-type>
         <jahia-module-signature>MC0CFQCV4PBIdJhVVMxsCWm1TXt0DjJtqgIUfKkgn6VUx5AZig0ZZ/NMR99vmnQ=</jahia-module-signature>
     </properties>

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardGWTResources.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardGWTResources.java
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferencePolicy;
 
-import java.util.List;
+import java.util.Collections;
 
 /**
  * @author Jerome Blanchard
@@ -39,7 +39,7 @@ public class JahiaCsrfGuardGWTResources extends ModuleGWTResources {
     @Reference(service = JahiaCsrfGuardGlobalConfig.class, policy = ReferencePolicy.DYNAMIC, updated = "setConfig")
     private void setConfig(JahiaCsrfGuardGlobalConfig config) {
         if (config != null) {
-            super.setJavascriptResources(List.of(config.getServletPath()));
+            super.setJavascriptResources(Collections.singletonList(config.getServletPath()));
         }
     }
 

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardGlobalConfig.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/JahiaCsrfGuardGlobalConfig.java
@@ -68,7 +68,7 @@ public class JahiaCsrfGuardGlobalConfig {
         this.setBypassForGuest(config.getOrDefault(BYPASS_FOR_GUEST, "true").equalsIgnoreCase("true"));
         this.setResolvedUrlPatterns(config.getOrDefault(RESOLVED_URL_PATTERNS, "").isEmpty() ?
                 new ArrayList<>() :
-                List.of(config.get(RESOLVED_URL_PATTERNS).split(",")));
+                Arrays.asList(config.get(RESOLVED_URL_PATTERNS).split(",")));
         this.setMultipartResolver(new CommonsMultipartResolver());
         this.setCrossSiteWriteProtectionEnabled(config.getOrDefault(CROSS_SITE_WRITE_PROTECTION_ENABLED, "true").equalsIgnoreCase("true"));
         LOGGER.debug("Updated Jahia CSRF Guard Global configuration: {}", this);

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/CsrfGuardJavascriptFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/CsrfGuardJavascriptFilter.java
@@ -39,7 +39,8 @@ import javax.servlet.http.HttpServletResponseWrapper;
 import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.Set;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -64,7 +65,7 @@ public final class CsrfGuardJavascriptFilter extends AbstractServletFilter {
         setFilterName("Jahia CSRF Guard Javascript Filter");
         setMatchAllUrls(true);
         setUrlPatterns(new String[]{"/*"});
-        setDispatcherTypes(Set.of(DispatcherType.REQUEST.name(), DispatcherType.FORWARD.name()));
+        setDispatcherTypes(new HashSet<>(Arrays.asList(DispatcherType.REQUEST.name(), DispatcherType.FORWARD.name())));
         setOrder(1.1f);
     }
 

--- a/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
+++ b/src/main/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilter.java
@@ -71,7 +71,7 @@ public class FetchMetadataFilter extends AbstractServletFilter {
         setMatchAllUrls(true);
         setUrlPatterns(new String[] { "/*" });
         // decide on the incoming request, before it is dispatched further and before the error page it may lead to
-        setDispatcherTypes(Set.of(DispatcherType.REQUEST.name()));
+        setDispatcherTypes(Collections.singleton(DispatcherType.REQUEST.name()));
         setOrder(-1.0f);
     }
 

--- a/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
+++ b/src/test/java/org/jahia/modules/jahiacsrfguard/filters/FetchMetadataFilterTest.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Map;
@@ -25,7 +26,7 @@ public class FetchMetadataFilterTest {
     @Before
     public void setUp() {
         filter = new FetchMetadataFilter();
-        filter.setGlobalConfig(globalConfig(Map.of()));
+        filter.setGlobalConfig(globalConfig(Collections.emptyMap()));
         filter.setConfigs(configFactory("/*", "*.saml"));
     }
 
@@ -154,13 +155,13 @@ public class FetchMetadataFilterTest {
 
     @Test
     public void policyOffServesEverything() {
-        filter.setGlobalConfig(globalConfig(Map.of(JahiaCsrfGuardGlobalConfig.CROSS_SITE_WRITE_PROTECTION_ENABLED, "false")));
+        filter.setGlobalConfig(globalConfig(Collections.singletonMap(JahiaCsrfGuardGlobalConfig.CROSS_SITE_WRITE_PROTECTION_ENABLED, "false")));
         assertFalse(filter.isRejected(request("POST", RENDER_URI, null, "cross-site")));
     }
 
     @Test
     public void moduleOffServesEverything() {
-        filter.setGlobalConfig(globalConfig(Map.of(JahiaCsrfGuardGlobalConfig.ENABLED, "false")));
+        filter.setGlobalConfig(globalConfig(Collections.singletonMap(JahiaCsrfGuardGlobalConfig.ENABLED, "false")));
         assertFalse(filter.isRejected(request("POST", RENDER_URI, null, "cross-site")));
     }
 

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.2.0.0</version>
+        <version>8.1.7.0</version>
     </parent>
 
     <groupId>org.jahia.test</groupId>
@@ -37,7 +37,6 @@
     <properties>
         <jahia-depends>default</jahia-depends>
         <jahia-module-type>templatesSet</jahia-module-type>
-        <jahia.plugin.version>6.10</jahia.plugin.version>
         <jahia.modules.importPackage>org.jahia.modules.jahiacsrfguard;version="[4,5)";resolution:=optional</jahia.modules.importPackage>
     </properties>
 

--- a/tests/jahia-module/src/main/java/org/foo/modules/dummycsrftest/actions/DummyAction.java
+++ b/tests/jahia-module/src/main/java/org/foo/modules/dummycsrftest/actions/DummyAction.java
@@ -30,6 +30,7 @@ import org.jahia.bin.ActionResult;
 import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.services.render.Resource;
 import org.jahia.services.render.URLResolver;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -60,7 +61,7 @@ public class DummyAction extends Action {
     @Override
     public ActionResult doExecute(HttpServletRequest req, RenderContext renderContext, Resource resource,
             JCRSessionWrapper session, Map<String, List<String>> parameters,
-            URLResolver urlResolver) {
+            URLResolver urlResolver) throws JSONException {
         LOGGER.info("** Dummy Action performed! **");
         JSONObject response = new JSONObject();
         response.put("message", "Dummy Action performed!");


### PR DESCRIPTION
## Summary

Restores compatibility with Java 8 on the `4_2_x` maintenance line, and makes CI build on Java 8 so the problem cannot come back unnoticed.

Full context in [this Slack thread](https://jahia.slack.com/archives/C0BM6644TT3/p1786699484478129).

## Why

The module targets Java 8 bytecode and declares `Require-Capability: osgi.ee ... JavaSE 1.8`, but it called `List.of`, `Set.of` and `Map.of`, which arrived in Java 9. Nothing caught this: with `-source`/`-target 1.8` alone, javac running on a Java 11 JDK still links against the Java 11 class library, so the calls compile and the class files still claim major version 52.

Three of those calls sat in `@Activate` methods. On a Java 8 runtime the components therefore failed to activate, the servlet filters were never registered, and the site was left with **no CSRF protection** while the bundle still reported `ACTIVE` — a silent loss of protection rather than a visible failure.

Jahia 8.1.9 lists Oracle JDK 8.x and OpenJDK 8.x as supported, so this is a supported configuration. The versions carrying the defect are 4.2.0 (three call sites) and 4.2.1 (four, after the `FetchMetadataFilter` backport); 4.1.0 and earlier are clean.

## Changes

- Replaced the four `List.of` / `Set.of` calls in the main sources and the three `Map.of` calls in the tests with Java 8 equivalents. `Collections.singletonList`, `Collections.singleton` and `Collections.singletonMap` keep the immutability the original calls had.
- Removed the `jahia.plugin.version` override. The pinned 6.12 mojos are Java 11 bytecode, so Maven on a Java 8 JDK cannot load them at all: the build died in `native2ascii` before compiling anything. The version inherited from the parent chain is 6.8, which is Java 8 bytecode. For reference, 6.9 is the newest Java 8 capable release; 6.10 through 6.13 are all Java 11.
- Switched the build container to the Java 8 image in `on-code-change.yml` and `on-merge.yml`, so a Java 9+ API now fails the build instead of passing silently.

## Validation

- `mvn clean package` green **on JDK 8** (`1.8.0_292`), all **24 tests** pass. This is what could not happen before the plugin change.
- Built bundle checked: all 18 classes at bytecode major 52, and `javap` reports **zero** references to `java/util/List.of`, `Set.of` or `Map.of`.
- `Require-Capability: osgi.ee ... JavaSE 1.8` is now a truthful declaration.
- No `commons-fileupload` import, so this line still resolves on Jahia 8.1.x.
- Deployed to a live Jahia **8.1.9.3**: the bundle reaches `ACTIVE`, the CSRF servlet serves a token, and an untokened multipart `POST` to a `.do` URL is rejected with a 302 to `/error.html`. That last check matters: it proves the filters actually registered, which is exactly what the `Set.of` call in `@Activate` used to prevent.


## Documentation

No change needed.

## ADR

None.
