### PR TITLE
chore: Bump version from 4.2.3-SN to 4.3.0-SN

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>jahia-csrf-guard</artifactId>
     <name>Jahia CSRF Guard</name>
-    <version>4.2.3-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (jahia-csrf-guard) to protect Jahia from CSRF attack.</description>
 
@@ -41,7 +41,7 @@
     <properties>
         <csrfguard.version>4.5.0</csrfguard.version>
         <jahia-module-type>system</jahia-module-type>
-        <jahia-module-signature>MC0CFQCV4PBIdJhVVMxsCWm1TXt0DjJtqgIUfKkgn6VUx5AZig0ZZ/NMR99vmnQ=</jahia-module-signature>
+        <jahia-module-signature>MCwCFGCMvjnACbYV//000laH3kahp0LAAhQ2g8QF/WPAVduRnDV+EccQSxL1Nw==</jahia-module-signature>
     </properties>
 
     <repositories>

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -30,7 +30,7 @@
     <groupId>org.jahia.test</groupId>
     <artifactId>jahia-csrf-guard-test-module</artifactId>
     <name>Jahia CSRF Guard Test Module</name>
-    <version>4.2.3-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (jahia-csrf-guard-test-module) for running on a Jahia server.</description>
 


### PR DESCRIPTION
### Description
Set the version of the https://github.com/Jahia/jahia-csrf-guard/tree/4_x maintenance branch to 4.3.0-SNAPSHOT (was 4.2.3-SNAPSHOT).

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
